### PR TITLE
remove Logger.metadata property

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -79,20 +79,6 @@ extension Logger {
         }
     }
 
-    /// Get or set the entire metadata storage.
-    ///
-    /// - note: Logging metadata behaves as a value that means a change to the logging metadata will only affect the
-    ///         very `Logger` it was changed on.
-    @inlinable
-    public var metadata: Logger.Metadata {
-        get {
-            return self.handler.metadata
-        }
-        set {
-            self.handler.metadata = newValue
-        }
-    }
-
     /// Get or set the log level configured for this `Logger`.
     ///
     /// - note: `Logger`s treat `logLevel` as a value. This means that a change in `logLevel` will only affect this

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -45,9 +45,7 @@ internal struct TestLogHandler: LogHandler {
 
     func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
         let metadata = (self._metadataSet ? self.metadata : MDC.global.metadata).merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
-        var l = logger // local copy since we gonna override its metadata
-        l.metadata = metadata
-        l.log(level: level, message, metadata: metadata, file: file, function: function, line: line)
+        logger.log(level: level, message, metadata: metadata, file: file, function: function, line: line)
         self.recorder.record(level: level, metadata: metadata, message: message)
     }
 


### PR DESCRIPTION
Motivation:

Logger had two ways to access the metadata:

    logger[metadataKey: "foo"] = "bar"

and

    logger.metadata["foo"] = "bar"

. The first one is the preferred API (as it doesn't force the
`LogHandler`s to store it in a dictionary) but the second one was still
available for cases where you need to import/export the whole metadata
storage.

Instead of exposing this as a dictionary, we should make the
'whole-metadata import/export' opaque. We're close to tagging 1.0.0
however let's design this API properly and add a sensible implementation
for 1.1.0 or so.

Moditications:

remove `Logger.metadata` property

Result:

- We can design the import/export APIs and add them when they're ready.
- the `LogHandler` API is unchanged
- fixes #31 