### PR TITLE
Support Swift 4.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:4.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Logging API open source project

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Logging API open source project

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -65,7 +65,6 @@ extension Lock {
     ///
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
-    @inlinable
     internal func withLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lock()
         defer {
@@ -75,7 +74,6 @@ extension Lock {
     }
 
     // specialise Void return (for performance)
-    @inlinable
     internal func withLockVoid(_ body: () throws -> Void) rethrows {
         try self.withLock(body)
     }
@@ -138,7 +136,6 @@ extension ReadWriteLock {
     ///
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
-    @inlinable
     internal func withReaderLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lockRead()
         defer {
@@ -155,7 +152,6 @@ extension ReadWriteLock {
     ///
     /// - Parameter body: The block to execute while holding the lock.
     /// - Returns: The value returned by the block.
-    @inlinable
     internal func withWriterLock<T>(_ body: () throws -> T) rethrows -> T {
         self.lockWrite()
         defer {
@@ -165,13 +161,11 @@ extension ReadWriteLock {
     }
 
     // specialise Void return (for performance)
-    @inlinable
     internal func withReaderLockVoid(_ body: () throws -> Void) rethrows {
         try self.withReaderLock(body)
     }
 
     // specialise Void return (for performance)
-    @inlinable
     internal func withWriterLockVoid(_ body: () throws -> Void) rethrows {
         try self.withWriterLock(body)
     }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -26,7 +26,6 @@
 ///     logger.info("Hello World!")
 ///
 public struct Logger {
-    @usableFromInline
     var handler: LogHandler
     public let label: String
 
@@ -52,7 +51,6 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func log(level: Logger.Level,
                     _ message: @autoclosure () -> Logger.Message,
                     metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -65,7 +63,6 @@ extension Logger {
         }
     }
 
-    @inlinable
     public func log(level: Logger.Level,
                     _ message: @autoclosure () -> String,
                     metadata: @autoclosure () -> [String: String]? = nil,
@@ -81,7 +78,6 @@ extension Logger {
     ///
     /// - note: Logging metadata behaves as a value that means a change to the logging metadata will only affect the
     ///         very `Logger` it was changed on.
-    @inlinable
     public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
         get {
             return self.handler[metadataKey: metadataKey]
@@ -97,7 +93,6 @@ extension Logger {
     ///         very `Logger`. It it acceptable for logging backends to have some form of global log level override
     ///         that affects multiple or even all loggers. This means a change in `logLevel` to one `Logger` might in
     ///         certain cases have no effect.
-    @inlinable
     public var logLevel: Logger.Level {
         get {
             return self.handler.logLevel
@@ -124,14 +119,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func trace(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .trace, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func trace(_ message: @autoclosure () -> String,
                       metadata: @autoclosure () -> [String: String]? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
@@ -155,14 +148,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func debug(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .debug, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func debug(_ message: @autoclosure () -> String,
                       metadata: @autoclosure () -> [String: String]? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
@@ -186,14 +177,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func info(_ message: @autoclosure () -> Logger.Message,
                      metadata: @autoclosure () -> Logger.Metadata? = nil,
                      file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .info, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func info(_ message: @autoclosure () -> String,
                      metadata: @autoclosure () -> [String: String]? = nil,
                      file: String = #file, function: String = #function, line: UInt = #line) {
@@ -217,14 +206,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func notice(_ message: @autoclosure () -> Logger.Message,
                        metadata: @autoclosure () -> Logger.Metadata? = nil,
                        file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .notice, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func notice(_ message: @autoclosure () -> String,
                        metadata: @autoclosure () -> [String: String]? = nil,
                        file: String = #file, function: String = #function, line: UInt = #line) {
@@ -248,14 +235,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func warning(_ message: @autoclosure () -> Logger.Message,
                         metadata: @autoclosure () -> Logger.Metadata? = nil,
                         file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .warning, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func warning(_ message: @autoclosure () -> String,
                         metadata: @autoclosure () -> [String: String]? = nil,
                         file: String = #file, function: String = #function, line: UInt = #line) {
@@ -279,14 +264,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func error(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .error, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func error(_ message: @autoclosure () -> String,
                       metadata: @autoclosure () -> [String: String]? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
@@ -309,14 +292,12 @@ extension Logger {
     ///                it defaults to `#file`.
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`.
-    @inlinable
     public func critical(_ message: @autoclosure () -> Logger.Message,
                          metadata: @autoclosure () -> Logger.Metadata? = nil,
                          file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .critical, message(), metadata: metadata(), file: file, function: function, line: line)
     }
 
-    @inlinable
     public func critical(_ message: @autoclosure () -> String,
                          metadata: @autoclosure () -> [String: String]? = nil,
                          file: String = #file, function: String = #function, line: UInt = #line) {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -214,7 +214,7 @@ class LoggingTest: XCTestCase {
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .debug
 
-        let someInt = Int.random(in: 23..<42)
+        let someInt = 42
         logger.debug("My favourite number is \(someInt) and not \(someInt - 1)")
         testLogging.history.assertExist(level: .debug,
                                         message: "My favourite number is \(someInt) and not \(someInt - 1)" as String)

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -27,8 +27,8 @@ class MDCTest: XCTestCase {
         for r in 5 ... 10 {
             group.enter()
             DispatchQueue(label: "mdc-test-queue-\(r)").async {
-                let add = Int.random(in: 10 ... 1000)
-                let remove = Int.random(in: 0 ... add - 1)
+                let add = 999
+                let remove = 123
                 for i in 0 ... add {
                     MDC.global["key-\(i)"] = .string("value-\(i)")
                 }


### PR DESCRIPTION
For some users, having Swift 4.1 support will be useful. Update the `jw-4.2-support` branch to support Swift 4.1.

Changes:

- Remove `@inlinable` and `@usableFromInline` annotations which were added in Swift 4.2. If the package is too slow, people should use Swift 5 and `from: "1.0.0"`.
- Remove `Int.random(in:)` which was added in Swift 4.2. Although this makes the tests slightly worse, it's NBD. (It was either that or start implementing `Int.random(in:)` via `arc4_random()` etc. and life is too short.)