### PR TITLE
fix typo in API docs

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -18,7 +18,7 @@
     import Glibc
 #endif
 
-/// A `Logger` is the central type in `swift-log`. Its central function is to emit log messages using one of the methods
+/// A `Logger` is the central type in `SwiftLog`. Its central function is to emit log messages using one of the methods
 /// corresponding to a log level.
 ///
 /// The most basic usage of a `Logger` is


### PR DESCRIPTION
motivation: better docs

changes: swidft-log -> SwiftLog in an API doc that got it wrong