### PR TITLE
fix linux tests formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,11 @@
+# file options
+
+# format options
+
+--self insert 
+--patternlet inline 
+--stripunusedargs unnamed-only 
+--comments ignore
+
+# rules
+

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -266,7 +266,7 @@ public enum LoggingSystem {
     /// - parameters:
     ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.
     public static func bootstrap(_ factory: @escaping (String) -> LogHandler) {
-        lock.withWriterLock {
+        self.lock.withWriterLock {
             precondition(!self.initialized, "logging system can only be initialized once per process.")
             self.factory = factory
             self.initialized = true
@@ -423,9 +423,9 @@ extension Logger {
     ///     logger.info("Hello \(world)")
     ///
     public struct Message: ExpressibleByStringLiteral,
-                           Equatable,
-                           CustomStringConvertible,
-                           ExpressibleByStringInterpolation {
+        Equatable,
+        CustomStringConvertible,
+        ExpressibleByStringInterpolation {
         public typealias StringLiteralType = String
 
         private var value: String
@@ -598,8 +598,7 @@ extension Logger.MetadataValue: CustomStringConvertible {
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
 // https://bugs.swift.org/browse/SR-9687
-extension Logger.MetadataValue: ExpressibleByStringInterpolation {
-}
+extension Logger.MetadataValue: ExpressibleByStringInterpolation {}
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
 // https://bugs.swift.org/browse/SR-9687

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,12 +23,12 @@ import XCTest
 ///
 
 #if os(Linux) || os(FreeBSD)
-   @testable import LoggingTests
+    @testable import LoggingTests
 
-   XCTMain([
-         testCase(GlobalLoggerTest.allTests),
-         testCase(LocalLoggerTest.allTests),
-         testCase(LoggingTest.allTests),
-         testCase(MDCTest.allTests),
+    XCTMain([
+        testCase(GlobalLoggerTest.allTests),
+        testCase(LocalLoggerTest.allTests),
+        testCase(LoggingTest.allTests),
+        testCase(MDCTest.allTests),
     ])
 #endif

--- a/Tests/LoggingTests/GlobalLoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest+XCTest.swift
@@ -23,13 +23,11 @@ import XCTest
 ///
 
 extension GlobalLoggerTest {
-
-   static var allTests : [(String, (GlobalLoggerTest) -> () throws -> Void)] {
-      return [
-                ("test1", test1),
-                ("test2", test2),
-                ("test3", test3),
-           ]
-   }
+    static var allTests: [(String, (GlobalLoggerTest) -> () throws -> Void)] {
+        return [
+            ("test1", test1),
+            ("test2", test2),
+            ("test3", test3),
+        ]
+    }
 }
-

--- a/Tests/LoggingTests/LocalLoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest+XCTest.swift
@@ -23,12 +23,10 @@ import XCTest
 ///
 
 extension LocalLoggerTest {
-
-   static var allTests : [(String, (LocalLoggerTest) -> () throws -> Void)] {
-      return [
-                ("test1", test1),
-                ("test2", test2),
-           ]
-   }
+    static var allTests: [(String, (LocalLoggerTest) -> () throws -> Void)] {
+        return [
+            ("test1", test1),
+            ("test2", test2),
+        ]
+    }
 }
-

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -23,26 +23,24 @@ import XCTest
 ///
 
 extension LoggingTest {
-
-   static var allTests : [(String, (LoggingTest) -> () throws -> Void)] {
-      return [
-                ("testAutoclosure", testAutoclosure),
-                ("testMultiplex", testMultiplex),
-                ("testDictionaryMetadata", testDictionaryMetadata),
-                ("testListMetadata", testListMetadata),
-                ("testStringConvertibleMetadata", testStringConvertibleMetadata),
-                ("testAutoClosuresAreNotForcedUnlessNeeded", testAutoClosuresAreNotForcedUnlessNeeded),
-                ("testLocalMetadata", testLocalMetadata),
-                ("testCustomFactory", testCustomFactory),
-                ("testAllLogLevelsExceptCriticalCanBeBlocked", testAllLogLevelsExceptCriticalCanBeBlocked),
-                ("testAllLogLevelsWork", testAllLogLevelsWork),
-                ("testLogMessageWithStringInterpolation", testLogMessageWithStringInterpolation),
-                ("testLoggingAString", testLoggingAString),
-                ("testMultiplexerIsValue", testMultiplexerIsValue),
-                ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
-                ("testLogLevelCases", testLogLevelCases),
-                ("testLogLevelOrdering", testLogLevelOrdering),
-           ]
-   }
+    static var allTests: [(String, (LoggingTest) -> () throws -> Void)] {
+        return [
+            ("testAutoclosure", testAutoclosure),
+            ("testMultiplex", testMultiplex),
+            ("testDictionaryMetadata", testDictionaryMetadata),
+            ("testListMetadata", testListMetadata),
+            ("testStringConvertibleMetadata", testStringConvertibleMetadata),
+            ("testAutoClosuresAreNotForcedUnlessNeeded", testAutoClosuresAreNotForcedUnlessNeeded),
+            ("testLocalMetadata", testLocalMetadata),
+            ("testCustomFactory", testCustomFactory),
+            ("testAllLogLevelsExceptCriticalCanBeBlocked", testAllLogLevelsExceptCriticalCanBeBlocked),
+            ("testAllLogLevelsWork", testAllLogLevelsWork),
+            ("testLogMessageWithStringInterpolation", testLogMessageWithStringInterpolation),
+            ("testLoggingAString", testLoggingAString),
+            ("testMultiplexerIsValue", testMultiplexerIsValue),
+            ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
+            ("testLogLevelCases", testLogLevelCases),
+            ("testLogLevelOrdering", testLogLevelOrdering),
+        ]
+    }
 }
-

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -108,7 +108,7 @@ class LoggingTest: XCTestCase {
     // Not thread-safe, thus should not be shared across threads.
     internal class LazyMetadataBox: CustomStringConvertible {
         private var makeValue: (() -> String)?
-        private var _value: String? = nil
+        private var _value: String?
 
         public init(_ makeValue: @escaping () -> String) {
             self.makeValue = makeValue
@@ -261,7 +261,7 @@ class LoggingTest: XCTestCase {
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .debug
 
-        let someInt = Int.random(in: 23..<42)
+        let someInt = Int.random(in: 23 ..< 42)
         logger.debug("My favourite number is \(someInt) and not \(someInt - 1)")
         testLogging.history.assertExist(level: .debug,
                                         message: "My favourite number is \(someInt) and not \(someInt - 1)" as String)
@@ -310,7 +310,7 @@ class LoggingTest: XCTestCase {
         struct LogHandlerWithGlobalLogLevelOverride: LogHandler {
             // the static properties hold the globally overridden log level (if overridden)
             private static let overrideLock = Lock()
-            private static var overrideLogLevel: Logger.Level? = nil
+            private static var overrideLogLevel: Logger.Level?
 
             private let recorder: Recorder
             // this holds the log level if not overridden
@@ -327,7 +327,7 @@ class LoggingTest: XCTestCase {
                 // when we get asked for the log level, we check if it was globally overridden or not
                 get {
                     return LogHandlerWithGlobalLogLevelOverride.overrideLock.withLock {
-                        return LogHandlerWithGlobalLogLevelOverride.overrideLogLevel
+                        LogHandlerWithGlobalLogLevelOverride.overrideLogLevel
                     } ?? self._logLevel
                 }
                 // we set the log level whenever we're asked (note: this might not have an effect if globally

--- a/Tests/LoggingTests/MDCTest+XCTest.swift
+++ b/Tests/LoggingTests/MDCTest+XCTest.swift
@@ -23,11 +23,9 @@ import XCTest
 ///
 
 extension MDCTest {
-
-   static var allTests : [(String, (MDCTest) -> () throws -> Void)] {
-      return [
-                ("test1", test1),
-           ]
-   }
+    static var allTests: [(String, (MDCTest) -> () throws -> Void)] {
+        return [
+            ("test1", test1),
+        ]
+    }
 }
-

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -252,11 +252,11 @@ public class MDC {
     }
 
     private var threadId: Int {
-      #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
-          return Int(pthread_mach_thread_np(pthread_self()))
-      #else
-          return Int(pthread_self())
-      #endif
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            return Int(pthread_mach_thread_np(pthread_self()))
+        #else
+            return Int(pthread_self())
+        #endif
     }
 }
 

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -71,17 +71,17 @@ def createExtensionFile(fileName, classes)
     file.write "\n"
 
     for classArray in classes
-      file.write 'extension ' + classArray[0] + " {\n\n"
-      file.write '   static var allTests : [(String, (' + classArray[0] + ") -> () throws -> Void)] {\n"
-      file.write "      return [\n"
+      file.write 'extension ' + classArray[0] + " {\n"
+      file.write '    static var allTests: [(String, (' + classArray[0] + ") -> () throws -> Void)] {\n"
+      file.write "        return [\n"
 
       for funcName in classArray[1]
-        file.write '                ("' + funcName + '", ' + funcName + "),\n"
+        file.write '            ("' + funcName + '", ' + funcName + "),\n"
       end
 
-      file.write "           ]\n"
-      file.write "   }\n"
-      file.write "}\n\n"
+      file.write "        ]\n"
+      file.write "    }\n"
+      file.write "}\n"
     end
   end
 end
@@ -96,10 +96,10 @@ def createLinuxMain(testsDirectory, allTestSubDirectories, files)
 
     file.write "#if os(Linux) || os(FreeBSD)\n"
     for testSubDirectory in allTestSubDirectories.sort { |x, y| x <=> y }
-      file.write '   @testable import ' + testSubDirectory + "\n"
+      file.write '    @testable import ' + testSubDirectory + "\n"
     end
     file.write "\n"
-    file.write "   XCTMain([\n"
+    file.write "    XCTMain([\n"
 
     testCases = []
     for classes in files
@@ -109,7 +109,7 @@ def createLinuxMain(testsDirectory, allTestSubDirectories, files)
     end
 
     for testCase in testCases.sort { |x, y| x <=> y }
-      file.write '         testCase(' + testCase + ".allTests),\n"
+      file.write '        testCase(' + testCase + ".allTests),\n"
     end
     file.write "    ])\n"
     file.write "#endif\n"


### PR DESCRIPTION
motivation: use consistent formatting

changes: update generate_linux_tests to match the formatting rules we use: `swiftformat --self insert --patternlet inline --stripunusedargs unnamed-only --comments ignore`