### PR TITLE
fix docker setup to use release version of swift 5

### DIFF
--- a/docker/docker-compose.1804.50.yaml
+++ b/docker/docker-compose.1804.50.yaml
@@ -8,8 +8,6 @@ services:
       args:
         ubuntu_version: "18.04"
         swift_version: "5.0"
-        swift_flavour: "DEVELOPMENT-SNAPSHOT-2019-03-06-a"
-        swift_builds_suffix: "branch"
 
   test:
     image: swift-log:18.04-5.0


### PR DESCRIPTION
motivation: swift 5 was already released, use the release version for CI

changes: remove the dev verion from docker compose setup