### PR TITLE
Fix typo in "critical" words in docs

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -326,7 +326,7 @@ extension Logger {
         /// Appropriate for error conditions.
         case error
 
-        /// Appropriate for criticial error conditions that usually require immediate
+        /// Appropriate for critical error conditions that usually require immediate
         /// attention.
         ///
         /// When a `critical` message is logged, the logging backend (`LogHandler`) is free to perform


### PR DESCRIPTION
Spotted while I was using the 1.0 of the API :)