### PR TITLE
Link to more appropriate (still open) Swift issue

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -572,7 +572,7 @@ internal struct StdoutLogHandler: LogHandler {
 }
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
-// https://bugs.swift.org/browse/SR-9687
+// https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
 
@@ -581,6 +581,8 @@ extension Logger.MetadataValue: ExpressibleByStringLiteral {
     }
 }
 
+// Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
+// https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -597,12 +599,12 @@ extension Logger.MetadataValue: CustomStringConvertible {
 }
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
-// https://bugs.swift.org/browse/SR-9687
+// https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: ExpressibleByStringInterpolation {
 }
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
-// https://bugs.swift.org/browse/SR-9687
+// https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: ExpressibleByDictionaryLiteral {
     public typealias Key = String
     public typealias Value = Logger.Metadata.Value
@@ -613,7 +615,7 @@ extension Logger.MetadataValue: ExpressibleByDictionaryLiteral {
 }
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
-// https://bugs.swift.org/browse/SR-9687
+// https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = Logger.Metadata.Value
 


### PR DESCRIPTION
The original issue that was https://bugs.swift.org/browse/SR-9687 has been closed as duplicate of https://bugs.swift.org/browse/SR-9686
Perhaps it would be less confusing for others reading the code if we linked to the not-closed issue?

Not a big deal, just something I noticed; if we want to continue to link to the original issue that's fine too.