### PR TITLE
Expose log handler "factory"

### DIFF
--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -38,6 +38,7 @@ extension LoggingTest {
             ("testLogMessageWithStringInterpolation", testLogMessageWithStringInterpolation),
             ("testLoggingAString", testLoggingAString),
             ("testMultiplexerIsValue", testMultiplexerIsValue),
+            ("testFactoryCanBeAccessed", testFactoryCanBeAccessed),
             ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -306,6 +306,27 @@ class LoggingTest: XCTestCase {
         logger1.error("hey")
     }
 
+    func testFactoryCanBeAccessed() {
+        var counter = 0
+        let fun: (String) -> LogHandler = { _ in
+            counter += 1
+            var handler = StdoutLogHandler(label: "-\(counter)")
+            handler.logLevel = .error // only to inspect that we got our "customized one" in the assertions below
+            return handler
+        }
+        LoggingSystem.bootstrapInternal(fun)
+
+        let l1 = Logger(label: "x")
+        XCTAssertTrue(l1.handler is StdoutLogHandler)
+        XCTAssertEqual(l1.handler.logLevel, .error)
+
+        let logHandler = LoggingSystem.factory("x")
+        XCTAssertTrue(logHandler is StdoutLogHandler)
+        XCTAssertEqual(logHandler.logLevel, .error)
+
+        XCTAssertEqual(counter, 2)
+    }
+
     func testLoggerWithGlobalOverride() {
         struct LogHandlerWithGlobalLogLevelOverride: LogHandler {
             // the static properties hold the globally overridden log level (if overridden)


### PR DESCRIPTION
Another "alignment with swift-metrics" issue I suppose, where we did decide to expose the factory.

Relates to: 
- This also relates to the question of making the factory a real type as well: _Align .bootstrap() style between SwiftLog and SwiftMetrics #52_

Reasoning: 

- When implementing a `LogHandler` which wants to *delegate*/*proxy* to "the real log handler," because maybe it is doing something with metadata or maybe it's a testing specialized one which captures all logged messages etc -- but I only set it some executions, not globally;
  - for the testing one one could consider if maybe importing `@testable` and then putting the proxying one there could be okey... but I'm not sure it's the only case
  - the "proxying one" nowadays has to create the `Logger()` and has to emit into it, rather than a to the handler directly (to get the "globally configured by user" logging), but could directly create the handler the user has configured globally and can delegate to it then.
- alignment between swift metrics and swift log: https://github.com/apple/swift-metrics/blob/master/Sources/CoreMetrics/Metrics.swift#L366-L369

Others:

- Should I remove the alias? It relates to #52, where I'd hope we could introduce a real type -- though that's up for debate as well I suppose.