### PR TITLE
add a CocoaPods podspec generator

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -35,7 +35,8 @@ This product contains a derivation of the Tony Stone's 'process_test_files.rb'.
 
 ---
 
-This product contains a derivation of SwiftNIO locks.
+This product contains a derivation of the lock implementation and various
+scripts from SwiftNIO.
 
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0

--- a/scripts/build_podspec.sh
+++ b/scripts/build_podspec.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift Logging API open source project
+##
+## Copyright (c) 2019 Apple Inc. and the Swift Logging API project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+function usage() {
+  echo "$0 [-u] version"
+  echo
+  echo "OPTIONS:"
+  echo "  -u: Additionally upload the podspec"
+}
+
+upload=false
+while getopts ":u" opt; do
+  case $opt in
+    u)
+      upload=true
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift "$((OPTIND-1))"
+
+if [[ $# -eq 0 ]]; then
+  echo "Must provide target version"
+  exit 1
+fi
+
+version=$1
+podspec_name="Logging"
+
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+tmpdir=$(mktemp -d /tmp/.build_podspecsXXXXXX)
+echo "Building podspec in $tmpdir"
+
+cat > "${tmpdir}/${podspec_name}.podspec" <<- EOF
+Pod::Spec.new do |s|
+  s.name = '$podspec_name'
+  s.version = '$version'
+  s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
+  s.summary = 'A Logging API for Swift.'
+  s.homepage = 'https://github.com/apple/swift-log'
+  s.author = 'Apple Inc.'
+  s.source = { :git => 'https://github.com/apple/swift-log.git', :tag => s.version.to_s }
+  s.documentation_url = 'https://apple.github.io/swift-log'
+  s.module_name = 'Logging'
+
+  s.swift_version = '5.0'
+  s.cocoapods_version = '>=1.6.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+
+  s.source_files = 'Sources/Logging/**/*.swift'
+end
+EOF
+
+if $upload; then
+  echo "Uploading ${tmpdir}/${podspec_name}.podspec"
+  pod trunk push "${tmpdir}/${podspec_name}.podspec"
+else
+  echo "Linting ${tmpdir}/${podspec_name}.podspec"
+  pod spec lint "${tmpdir}/${podspec_name}.podspec"
+fi

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -13,8 +13,27 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftNIO open source project
+##
+## Copyright (c) 2017-2019 Apple Inc. and the SwiftNIO project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of SwiftNIO project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function replace_acceptable_years() {
+    # this needs to replace all acceptable forms with 'YEARS'
+    sed -e 's/2018-2019/YEARS/' -e 's/2019/YEARS/'
+}
 
 printf "=> Checking linux tests... "
 FIRST_OUT="$(git status --porcelain)"
@@ -45,7 +64,7 @@ for language in swift-or-c bash dtrace; do
 //
 // This source file is part of the Swift Logging API open source project
 //
-// Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+// Copyright (c) YEARS Apple Inc. and the Swift Logging API project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -64,7 +83,7 @@ EOF
 ##
 ## This source file is part of the Swift Logging API open source project
 ##
-## Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+## Copyright (c) YEARS Apple Inc. and the Swift Logging API project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -83,7 +102,7 @@ EOF
  *
  *  This source file is part of the Swift Logging API open source project
  *
- *  Copyright (c) 2018-2019 Apple Inc. and the Swift Logging API project authors
+ *  Copyright (c) YEARS Apple Inc. and the Swift Logging API project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information
@@ -108,9 +127,9 @@ EOF
       \( \! -path './.build/*' -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) \) | while read line; do
-      if [[ "$(cat "$line" | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
+      if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
-        diff -u <(cat "$line" | head -n $expected_lines) "$tmp"
+        diff -u <(cat "$line" | replace_acceptable_years | head -n $expected_lines) "$tmp"
         exit 1
       fi
     done


### PR DESCRIPTION
Motivation:

Users ask for a CocoaPod. Unfortunately, the CocodPod `SwiftLog` is
already taken, so I went for `SwiftLogAPI`.

Modification:

Add a podspec generator.

Result:

- Happier users.
- fixes #19 

---

Example output:

```
Pod::Spec.new do |s|
  s.name = 'SwiftLogAPI'
  s.version = '1.0.0'
  s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
  s.summary = 'A Logging API for Swift.'
  s.homepage = 'https://github.com/apple/swift-log'
  s.author = 'Apple Inc.'
  s.source = { :git => 'https://github.com/apple/swift-log.git', :tag => s.version.to_s }
  s.documentation_url = 'https://github.com/apple/swift-log'
  s.module_name = 'Logging'

  s.swift_version = '5.0'
  s.cocoapods_version = '>=1.6.0'
  s.ios.deployment_target = '12.0'
  s.osx.deployment_target = '10.14'
  s.tvos.deployment_target = '12.0'

  s.source_files = 'Sources/Logging/**/*.swift'
end
```