### PR TITLE
Introduce LogHandlerFactory and align .bootstrap() style with SwiftMetrics #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ logger.info("Hello World!")
 
 For further information, please check the [API documentation][api-docs].
 
+### Selecting a logging backend implementation (applications only)
+
+Note: If you are building a library, you don't need to concern yourself with this section. 
+It is the end users of your library (the applications) who will decide which logging backend to use. 
+Libraries should never change the logging implementation as that is something owned by the application.
+
+SwiftLog only provides the logging system API. 
+As an application owner, you may want to select a logging backend different than the built-in minimal standard out 
+implementation in order to make the logging information more useful.
+
+Selecting a backend is done by adding a dependency on the desired backend client implementation and invoking the `LoggingSystem.bootstrap` function at the beginning of the program: 
+
+```swift 
+LoggingSystem.bootstrap(SelectedLoggingImplementation())
+```
+
+This instructs the `LoggingSystem` to install `SelectedLoggingImplementation` (actual name will differ) as the logging backend to use.
+
+As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementing a logging backend" section below explaining how to do so.
+ 
+List of existing SwiftLog API compatible libraries:
+
+- Your library? [Get in touch!](https://forums.swift.org/c/server)
+
 ## What is an API package?
 
 Glad you asked. We believe that for the Swift on Server ecosystem, it's crucial to have a logging API that can be adopted by anybody so a multitude of libraries from different parties can all log to a shared destination. More concretely this means that we believe all the log messages from all libraries end up in the same file, database, Elastic Stack/Splunk instance, or whatever you may choose.

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -18,7 +18,7 @@ class GlobalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.debug)
@@ -45,7 +45,7 @@ class GlobalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)
@@ -72,7 +72,7 @@ class GlobalLoggerTest: XCTestCase {
     func test3() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // change test logging config
         logging.config.set(value: .warning)

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -18,7 +18,7 @@ class LocalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.debug)
@@ -46,7 +46,7 @@ class LocalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -19,7 +19,7 @@ class MDCTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logger
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging)
 
         // run the program
         MDC.global["foo"] = "bar"

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -15,7 +15,8 @@ import Foundation
 @testable import Logging
 import XCTest
 
-internal struct TestLogging {
+/// Internal `TestLogHandler` factory, which can be used to inspect the recorded log statements.
+internal struct TestLogging: LogHandlerFactory {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 


### PR DESCRIPTION
Align the style of `SwiftLog` with the other official SSWG API that was recently accepted: https://github.com/apple/swift-metrics

### Depends on:

- `Expose log handler "factory"` #53 

### Motivation:

- align style of library and creating instances to https://github.com/apple/swift-metrics
  - both APIs are very similar, having the same "look and feel" will be beneficial for understandability and adoption
  - also sets some more precedence for other libraries in SSWG to follow this style
- Having an explicit Factory type makes a lot of sense and implementations more complex than print / log to file will likely need some shared "container" for their config or other things; Examples:
  - an async logger would want to _accept_ an event loop or other execution context when configuring the logger, 
  - a networking logging client would take configuration of which endpoint to send data to, this is configured on "the logging library level", and not per handler really, even if per handle may have slight different configs
- Avoid having the APIs be great for the purpose of "our tests" but a bit weird for outside users. 
  - The `LoggingSystem.bootstrap(Handler.make)` and `LoggingSystem.bootstrap(Handler.init)` feels like it is great for "us" since it makes writing weird one off handlers super simple, but in practice we anticipate less of this use case, and more of logging libraries offering their "boostrap with my Factory type please," at least IMHO.

### Modifications:

- introduces an explicit `LogHandlerFactory` type
  - bootstrap methods accept it explicitly

### Result:

- More similar API design to the Metrics API
- Provides default "go to" place for keeping logging library configuration / resources
- Makes exposing the Factory (PR: #53) a bit more natural, even through this is a small use case.
- Resolves https://github.com/apple/swift-log/issues/52