### PR TITLE
RFC: log to stderr not stdout [might not take this one]

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -284,7 +284,7 @@ class LoggingTest: XCTestCase {
     }
 
     func testMultiplexerIsValue() {
-        let multi = MultiplexLogHandler([StdoutLogHandler(label: "x"), StdoutLogHandler(label: "y")])
+        let multi = MultiplexLogHandler([StderrLogHandler(label: "x"), StderrLogHandler(label: "y")])
         LoggingSystem.bootstrapInternal { _ in
             print("new multi")
             return multi

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -39,7 +39,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StdoutLogHandler(label: label))
+        self.logger = Logger(label: "test", StderrLogHandler(label: label))
         self.logger.logLevel = .debug
     }
 


### PR DESCRIPTION
Motivation:

Logging to stderr makes more sense as it enables command line utilities
to log.

Modifications:

Log to stderr, not stdout

Result:

more useful
