### PR TITLE
Expose an API for configuring basic stdio log handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ logger.info("Hello World!")
 
 `SwiftLog` provides for very basic console logging out-of-the-box by way of `StreamLogHandler`. It is possible to switch the default output to `stderr` like so:
 ```
-LoggingSystem.bootstrap(StreamLogHandler.makeStderrLogHandler)
+LoggingSystem.bootstrap(StreamLogHandler.standardError)
 ```
 
 `StreamLogHandler` is primarily a convenience only and does not provide any substantial customization. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section.

--- a/README.md
+++ b/README.md
@@ -45,16 +45,12 @@ logger.info("Hello World!")
 
 #### Default `Logger` behavior
 
-`SwiftLog` provides very basic console logging out-of-the-box by way of `StreamLogHandler`. It is possible to switch the default output to `stderr` like so:
+`SwiftLog` provides for very basic console logging out-of-the-box by way of `StreamLogHandler`. It is possible to switch the default output to `stderr` like so:
 ```
-LoggingSystem.bootstrap { label in
-    StreamLogHandler(label: label, stream: StdioOutputStream.stderr)
-}
+LoggingSystem.bootstrap(StreamLogHandler.makeStderrLogHandler)
 ```
 
-`StreamLogHandler` is customizable through the `StreamLogHandler.init(label:stream:)` initializer. You can pass in a type comforming to `TextOuputStream` to redirect `StreamLogHandler`'s ultimate output destination. The custom `TextOutputStream` should handle any necessary synchronization logic to ensure logs from different threads are never interleved. `write(_:)` will be called exactly 1 time for each log.
-
-`StreamLogHandler`'s customization API is primarily a convenience to _very simple use-cases_. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section. `StreamLogHandler` intentionally does not allow customizing the format string as that is beyond the scope of the implementation.
+`StreamLogHandler` is primarily a convenience only and does not provide any substantial customization. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section.
 
 For further information, please check the [API documentation][api-docs].
 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ logger.info("Hello World!")
 `SwiftLog` provides very basic console logging out-of-the-box by way of `StreamLogHandler`. It is possible to switch the default output to `stderr` like so:
 ```
 LoggingSystem.bootstrap { label in
-    StreamLogHandler(label: label, stream: .stderr)
+    StreamLogHandler(label: label, stream: StdioOutputStream.stderr)
 }
 ```
 
-`StreamLogHandler` is customizable through the `StreamLogHandler.Stream` API. You can pass in a type comforming to `TextOuputStream` to redirect `StreamLogHandler`'s ultimate output destination. The type provided to `Stream.init(underlying:)` should handle any synchronization logic to ensure logs from different threads are never interleved.
+`StreamLogHandler` is customizable through the `StreamLogHandler.init(label:stream:)` initializer. You can pass in a type comforming to `TextOuputStream` to redirect `StreamLogHandler`'s ultimate output destination. The custom `TextOutputStream` should handle any necessary synchronization logic to ensure logs from different threads are never interleved. `write(_:)` will be called exactly 1 time for each log.
 
-`StreamLogHandler`'s customization API is primarily a convenience to _very simple use-cases_. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section.
+`StreamLogHandler`'s customization API is primarily a convenience to _very simple use-cases_. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section. `StreamLogHandler` intentionally does not allow customizing the format string as that is beyond the scope of the implementation.
 
 For further information, please check the [API documentation][api-docs].
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ logger.info("Hello World!")
 2019-03-13T15:46:38+0000 info: Hello World!
 ```
 
+#### Default `Logger` behavior
+
+`SwiftLog` provides very basic console logging out-of-the-box by way of `StreamLogHandler`. It is possible to switch the default output to `stderr` like so:
+```
+LoggingSystem.bootstrap { label in
+    StreamLogHandler(label: label, stream: .stderr)
+}
+```
+
+`StreamLogHandler` is customizable through the `StreamLogHandler.Stream` API. You can pass in a type comforming to `TextOuputStream` to redirect `StreamLogHandler`'s ultimate output destination. The type provided to `Stream.init(underlying:)` should handle any synchronization logic to ensure logs from different threads are never interleved.
+
+`StreamLogHandler`'s customization API is primarily a convenience to _very simple use-cases_. Library maintainers who aim to build their own logging backends for integration and consumption should implement the `LogHandler` protocol directly as laid out in the "On the implementation of a logging backend" section.
+
 For further information, please check the [API documentation][api-docs].
 
 ## What is an API package?

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -530,7 +530,7 @@ public struct StdioLogHandler: LogHandler {
         self.init(label: label, stream: .stdout)
     }
 
-    public init(label: String, stream: Stream = .stdout) {
+    public init(label: String, stream: Stream) {
         self.stream = stream
     }
 

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -525,11 +525,9 @@ public struct StdioLogHandler: LogHandler {
 
     private let lock = Lock()
     public let stream: Stream
-    private let output: FileOutputStream
 
     public init(label: String, stream: Stream = .stdout) {
         self.stream = stream
-        output = FileOutputStream(file: stream == .stdout ? stdout : stderr)
     }
 
     private var _logLevel: Logger.Level = .info
@@ -560,7 +558,7 @@ public struct StdioLogHandler: LogHandler {
             ? self.prettyMetadata
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
-        var output = self.output
+        var output = FileOutputStream(file: stream == .stdout ? stdout : stderr)
         print("\(self.timestamp()) \(level):\(prettyMetadata.map { " \($0)" } ?? "") \(message)", to: &output)
     }
 

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -506,7 +506,7 @@ public struct MultiplexLogHandler: LogHandler {
 }
 
 /// Ships with the logging module, really boring just prints something using the `print` function
-internal struct StdoutLogHandler: LogHandler {
+public struct StdoutLogHandler: LogHandler {
     private let lock = Lock()
 
     public init(label: String) {}

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -258,7 +258,7 @@ extension Logger {
 /// implementation.
 public enum LoggingSystem {
     fileprivate static let lock = ReadWriteLock()
-    fileprivate static var factory: (String) -> LogHandler = StreamLogHandler.makeStdoutLogHandler
+    fileprivate static var factory: (String) -> LogHandler = StreamLogHandler.standardOutput
     fileprivate static var initialized = false
 
     /// `bootstrap` is a one-time configuration function which globally selects the desired logging backend
@@ -539,12 +539,12 @@ let systemStdout = Glibc.stdout!
 public struct StreamLogHandler: LogHandler {
 
     /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
-    public static func makeStdoutLogHandler(label: String) -> StreamLogHandler {
+    public static func standardOutput(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout)
     }
 
     /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
-    public static func makeStderrLogHandler(label: String) -> StreamLogHandler {
+    public static func standardError(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr)
     }
 

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -511,6 +511,10 @@ private struct FileOutputStream: TextOutputStream {
 
     func write(_ string: String) {
         string.withCString { ptr in
+            flockfile(file)
+            defer {
+                funlockfile(file)
+            }
             _ = fputs(ptr, file)
         }
     }

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -41,8 +41,8 @@ extension LoggingTest {
             ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),
-            ("testStdioLogHandlerOutputsToStderr", testStdioLogHandlerOutputsToStderr),
-            ("testStdioLogHandlerDefaultsToStdout", testStdioLogHandlerDefaultsToStdout),
+            ("testStreamLogHandlerOutputsToStderr", testStreamLogHandlerOutputsToStderr),
+            ("testStreamLogHandlerDefaultsToStdout", testStreamLogHandlerDefaultsToStdout),
         ]
     }
 }

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -41,7 +41,8 @@ extension LoggingTest {
             ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),
-            ("testStreamLogHandlerOutputsToStderr", testStreamLogHandlerOutputsToStderr),
+            ("testStreamLogHandlerCallsWriteOncePerLog", testStreamLogHandlerCallsWriteOncePerLog),
+            ("testStreamLogHandlerPrintsToAStream", testStreamLogHandlerPrintsToAStream),
             ("testStreamLogHandlerDefaultsToStdout", testStreamLogHandlerDefaultsToStdout),
         ]
     }

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -41,9 +41,7 @@ extension LoggingTest {
             ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),
-            ("testStreamLogHandlerCallsWriteOncePerLog", testStreamLogHandlerCallsWriteOncePerLog),
-            ("testStreamLogHandlerPrintsToAStream", testStreamLogHandlerPrintsToAStream),
-            ("testStreamLogHandlerDefaultsToStdout", testStreamLogHandlerDefaultsToStdout),
+            ("testStreamLogHandlerWritesToAStream", testStreamLogHandlerWritesToAStream),
         ]
     }
 }

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -41,6 +41,8 @@ extension LoggingTest {
             ("testLoggerWithGlobalOverride", testLoggerWithGlobalOverride),
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),
+            ("testStdioLogHandlerOutputsToStderr", testStdioLogHandlerOutputsToStderr),
+            ("testStdioLogHandlerDefaultsToStdout", testStdioLogHandlerDefaultsToStdout),
         ]
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -420,13 +420,15 @@ class LoggingTest: XCTestCase {
 
     class InterceptStream: TextOutputStream {
         var interceptedText: String?
+        var strings = [String]()
 
         func write(_ string: String) {
+            strings.append(string)
             interceptedText = (interceptedText ?? "") + string
         }
     }
 
-    func testStdioLogHandlerOutputsToStderr() {
+    func testStreamLogHandlerOutputsToStderr() {
         let interceptStream = InterceptStream()
         LoggingSystem.bootstrapInternal { _ in
             StreamLogHandler(label: "test", stream: StreamLogHandler.Stream(underlying: interceptStream))
@@ -441,7 +443,7 @@ class LoggingTest: XCTestCase {
         XCTAssertTrue(messageSucceeded ?? false)
     }
 
-    func testStdioLogHandlerDefaultsToStdout() {
+    func testStreamLogHandlerDefaultsToStdout() {
 
         let interceptStream = InterceptStream()
         LoggingSystem.bootstrapInternal { _ in

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -284,7 +284,7 @@ class LoggingTest: XCTestCase {
     }
 
     func testMultiplexerIsValue() {
-        let multi = MultiplexLogHandler([StreamLogHandler.makeStdoutLogHandler(label: "x"), StreamLogHandler.makeStdoutLogHandler(label: "y")])
+        let multi = MultiplexLogHandler([StreamLogHandler.standardOutput(label: "x"), StreamLogHandler.standardOutput(label: "y")])
         LoggingSystem.bootstrapInternal { _ in
             print("new multi")
             return multi

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -284,7 +284,7 @@ class LoggingTest: XCTestCase {
     }
 
     func testMultiplexerIsValue() {
-        let multi = MultiplexLogHandler([StreamLogHandler(label: "x"), StreamLogHandler(label: "y")])
+        let multi = MultiplexLogHandler([StreamLogHandler.makeStdoutLogHandler(label: "x"), StreamLogHandler.makeStdoutLogHandler(label: "y")])
         LoggingSystem.bootstrapInternal { _ in
             print("new multi")
             return multi
@@ -429,21 +429,7 @@ class LoggingTest: XCTestCase {
         }
     }
 
-    /// This scenario is required to ensure locking is effective
-    func testStreamLogHandlerCallsWriteOncePerLog() {
-        let interceptStream = InterceptStream()
-        LoggingSystem.bootstrapInternal { _ in
-            StreamLogHandler(label: "test", stream: interceptStream)
-        }
-        let log = Logger(label: "test")
-
-        let testString = "test stdout"
-        log.critical("\(testString)")
-
-        XCTAssertEqual(interceptStream.strings.count, 1)
-    }
-
-    func testStreamLogHandlerPrintsToAStream() {
+    func testStreamLogHandlerWritesToAStream() {
         let interceptStream = InterceptStream()
         LoggingSystem.bootstrapInternal { _ in
             StreamLogHandler(label: "test", stream: interceptStream)
@@ -456,13 +442,6 @@ class LoggingTest: XCTestCase {
         let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(testString)
 
         XCTAssertTrue(messageSucceeded ?? false)
-    }
-
-    func testStreamLogHandlerDefaultsToStdout() {
-
-        let stdoutStream = StdioOutputStream.stdout
-        let streamLogHandler = StreamLogHandler(label: "test")
-
-        XCTAssertEqual(stdoutStream.file, (streamLogHandler.stream as! StdioOutputStream).file)
+        XCTAssertEqual(interceptStream.strings.count, 1)
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -284,7 +284,7 @@ class LoggingTest: XCTestCase {
     }
 
     func testMultiplexerIsValue() {
-        let multi = MultiplexLogHandler([StdoutLogHandler(label: "x"), StdoutLogHandler(label: "y")])
+        let multi = MultiplexLogHandler([StdioLogHandler(label: "x"), StdioLogHandler(label: "y")])
         LoggingSystem.bootstrapInternal { _ in
             print("new multi")
             return multi

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -39,7 +39,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StdioLogHandler(label: label))
+        self.logger = Logger(label: "test", StreamLogHandler(label: label))
         self.logger.logLevel = .debug
     }
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -39,7 +39,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StreamLogHandler.makeStdoutLogHandler(label: label))
+        self.logger = Logger(label: "test", StreamLogHandler.standardOutput(label: label))
         self.logger.logLevel = .debug
     }
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -39,7 +39,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StdoutLogHandler(label: label))
+        self.logger = Logger(label: "test", StdioLogHandler(label: label))
         self.logger.logLevel = .debug
     }
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -39,7 +39,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StreamLogHandler(label: label))
+        self.logger = Logger(label: "test", StreamLogHandler.makeStdoutLogHandler(label: label))
         self.logger.logLevel = .debug
     }
 


### PR DESCRIPTION
Expose `StreamLogHandler` to the public which replaces the previously internal `StdoutLogHandlers`. Users can choose now the output stream, while `stdout` is the default.

### Motivation:

As discussed on #51 and #60

### Modifications:

Rename `StdoutLogHandler` to `StreamLogHandler` and provide 2 factory methods `standardOutput(label:)` and `standardError(label:)` for using during bootstrapping.

### Result:

Users who adopt other logging backends during `LoggingSystem` bootstrapping will still be able to use the default log handler to get very basic console output to their choice of `stdout` or `stderr`.

### Example:
```
// Log to both stderr and stdout for good measure
LoggingSystem.bootstrap { 
    MultiplexLogHandler([
        FancyLoggingBackend(label: $0),
        StreamLogHandler.standardError(label: $0), 
        StreamLogHandler.standardOutput(label: $0)
    ])
}
```