### PR TITLE
count > 0 to !isEmpty

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -449,7 +449,7 @@ public struct MultiplexLogHandler: LogHandler {
     private var handlers: [LogHandler]
 
     public init(_ handlers: [LogHandler]) {
-        assert(handlers.count > 0)
+        assert(!handlers.isEmpty)
         self.handlers = handlers
     }
 


### PR DESCRIPTION
Change `handlers.count > 0`-> `!handlers.isEmpty`

### Motivation:

Performance improvement.
see: https://developer.apple.com/documentation/swift/array/1688398-isempty

