### PR TITLE
Add HeliumLogger to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For further information, please check the [API documentation][api-docs].
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 
+- [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger) - a logging backend widely used in the Kitura ecosystem
 - [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) – a [syslog](https://en.wikipedia.org/wiki/Syslog) backend
 - [Adorkable/swift-log-**format-and-pipe**](https://github.com/Adorkable/swift-log-format-and-pipe) – a backend that allows customization of the output format and the resulting destination
 - Your library? [Get in touch!](https://forums.swift.org/c/server)


### PR DESCRIPTION
The latest version of HeliumLogger can work as a `swift-log` backend, so mention it in the README.