### PR TITLE
Add `swift-log-oslog` logging backend link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 - [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger) - a logging backend widely used in the Kitura ecosystem
 - [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) – a [syslog](https://en.wikipedia.org/wiki/Syslog) backend
 - [Adorkable/swift-log-**format-and-pipe**](https://github.com/Adorkable/swift-log-format-and-pipe) – a backend that allows customization of the output format and the resulting destination
+- [chrisaljoudi/swift-log-**oslog**](https://github.com/chrisaljoudi/swift-log-oslog) - an OSLog [Unified Logging](https://developer.apple.com/documentation/os/logging) backend for use on Apple platforms
 - Your library? [Get in touch!](https://forums.swift.org/c/server)
 
 ## What is an API package?


### PR DESCRIPTION
Just created a simple `OSLog` backend implementing `LogHandler`. This is the recommended way to do unified logging on Apple platforms, so it seems like a good backend implementation to list.

This PR is just to add the link to [the repo](https://github.com/chrisaljoudi/swift-log-oslog).