### PR TITLE
Remove level documentation from log helpers

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -105,7 +105,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -127,7 +126,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -149,7 +147,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -171,7 +168,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -193,7 +189,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -215,7 +210,6 @@ extension Logger {
     /// otherwise nothing will happen.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
@@ -236,7 +230,6 @@ extension Logger {
     /// `.critical` messages will always be logged.
     ///
     /// - parameters:
-    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it


### PR DESCRIPTION
Removed the level documentation from log helpers

### Motivation:

Currently the documentation for the `Logger` helper functions contains a log level, when these functions do not take in a log level. Presumably from being copied from the main log function. 

### Modifications:

I've removed these documentation lines for the extension functions, the `log` one has not been removed. 

### Result:

Developers looking at the documentation for these functions will see the correct parameters documented. 