### PR TITLE
Add .swiftpm to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /*.xcodeproj
 .xcode
 DerivedData
+.swiftpm
 
 .SourceKitten/
 docs/


### PR DESCRIPTION
Add .swiftpm to .gitignore file

### Motivation:

This directory is Xcode specific and shouldn't be included in the index

### Modifications:

Add .swiftpm to .gitignore

### Result:

The repo is no longer dirtied by opening the package in Xcode
