### PR TITLE
Add amzn/smoke-http to the list of compatible libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ For further information, please check the [API documentation][api-docs].
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 
-- [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger) - a logging backend widely used in the Kitura ecosystem
-- [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) – a [syslog](https://en.wikipedia.org/wiki/Syslog) backend
 - [Adorkable/swift-log-**format-and-pipe**](https://github.com/Adorkable/swift-log-format-and-pipe) – a backend that allows customization of the output format and the resulting destination
-- [chrisaljoudi/swift-log-**oslog**](https://github.com/chrisaljoudi/swift-log-oslog) - an OSLog [Unified Logging](https://developer.apple.com/documentation/os/logging) backend for use on Apple platforms
+- [amzn/smoke-http](https://github.com/amzn/smoke-http) - HTTP client and utilities
 - [Brainfinance/StackdriverLogging](https://github.com/Brainfinance/StackdriverLogging) - a structured JSON logging backend for use on Google Cloud Platform with the [Stackdriver logging agent](https://cloud.google.com/logging/docs/agent) 
+- [chrisaljoudi/swift-log-**oslog**](https://github.com/chrisaljoudi/swift-log-oslog) - an OSLog [Unified Logging](https://developer.apple.com/documentation/os/logging) backend for use on Apple platforms
+- [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) – a [syslog](https://en.wikipedia.org/wiki/Syslog) backend
+- [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger) - a logging backend widely used in the Kitura ecosystem
 - [vapor/console-kit](https://github.com/vapor/console-kit/) - print log messages to a terminal with stylized ([ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code)) output
 - Your library? [Get in touch!](https://forums.swift.org/c/server)
 


### PR DESCRIPTION
Motivation:

[amzn/smoke-http](https://github.com/amzn/smoke-http) has adopted swift-log.

Modifications:
- Add amzn/smoke-http to the list of compatible libraries.
- Rearrange list in alphabetic order.

Result:
An expanded list of compatible libraries.
