### PR TITLE
Reformatted backend list as a table and add swift-log-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,16 @@ For further information, please check the [API documentation][api-docs].
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 
-- [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger) - a logging backend widely used in the Kitura ecosystem
-- [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) – a [syslog](https://en.wikipedia.org/wiki/Syslog) backend
-- [Adorkable/swift-log-**format-and-pipe**](https://github.com/Adorkable/swift-log-format-and-pipe) – a backend that allows customization of the output format and the resulting destination
-- [chrisaljoudi/swift-log-**oslog**](https://github.com/chrisaljoudi/swift-log-oslog) - an OSLog [Unified Logging](https://developer.apple.com/documentation/os/logging) backend for use on Apple platforms
-- [Brainfinance/StackdriverLogging](https://github.com/Brainfinance/StackdriverLogging) - a structured JSON logging backend for use on Google Cloud Platform with the [Stackdriver logging agent](https://cloud.google.com/logging/docs/agent) 
-- [vapor/console-kit](https://github.com/vapor/console-kit/) - print log messages to a terminal with stylized ([ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code)) output
-- Your library? [Get in touch!](https://forums.swift.org/c/server)
+| Repository | Handler Description|
+| ----------- | ----------- |
+| [IBM-Swift/HeliumLogger](https://github.com/IBM-Swift/HeliumLogger)  |a logging backend widely used in the Kitura ecosystem |
+| [ianpartridge/swift-log-**syslog**](https://github.com/ianpartridge/swift-log-syslog) | a [syslog](https://en.wikipedia.org/wiki/Syslog) backend|
+| [Adorkable/swift-log-**format-and-pipe**](https://github.com/Adorkable/swift-log-format-and-pipe) | a backend that allows customization of the output format and the resulting destination |
+| [chrisaljoudi/swift-log-**oslog**](https://github.com/chrisaljoudi/swift-log-oslog) | an OSLog [Unified Logging](https://developer.apple.com/documentation/os/logging) backend for use on Apple platforms |
+| [Brainfinance/StackdriverLogging](https://github.com/Brainfinance/StackdriverLogging) | a structured JSON logging backend for use on Google Cloud Platform with the [Stackdriver logging agent](https://cloud.google.com/logging/docs/agent) | 
+| [vapor/console-kit](https://github.com/vapor/console-kit/) | print log messages to a terminal with stylized ([ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code)) output |
+| [neallester/swift-log-testing](https://github.com/neallester/swift-log-testing) | provides access to log messages for use in assertions (within test targets) | 
+| Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?
 


### PR DESCRIPTION
[See Issue #105](https://github.com/apple/swift-log/issues/105)

### Modifications:

- Happy problem, the backend implementation list is now too long to look nice as an unordered list. Reformatted as a table.
- Added a new backend implementation: swift-log-testing.

### Result:

The README.md will look a bit better and will contain an additional backend implementation. 