### PR TITLE
[feat] StreamLogHandler now adds label to log output

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -578,6 +578,7 @@ public struct StreamLogHandler: LogHandler {
     }
 
     private let stream: TextOutputStream
+    private let label: String
 
     public var logLevel: Logger.Level = .info
 
@@ -599,6 +600,7 @@ public struct StreamLogHandler: LogHandler {
 
     // internal for testing only
     internal init(label: String, stream: TextOutputStream) {
+        self.label = label
         self.stream = stream
     }
 
@@ -611,7 +613,7 @@ public struct StreamLogHandler: LogHandler {
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
         var stream = self.stream
-        stream.write("\(self.timestamp()) \(level):\(prettyMetadata.map { " \($0)" } ?? "") \(message)\n")
+        stream.write("\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") \(message)\n")
     }
 
     private func prettify(_ metadata: Logger.Metadata) -> String? {

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -42,6 +42,8 @@ extension LoggingTest {
             ("testLogLevelCases", testLogLevelCases),
             ("testLogLevelOrdering", testLogLevelOrdering),
             ("testStreamLogHandlerWritesToAStream", testStreamLogHandlerWritesToAStream),
+            ("testStreamLogHandlerOutputFormat", testStreamLogHandlerOutputFormat),
+            ("testStreamLogHandlerOutputFormatWithMetaData", testStreamLogHandlerOutputFormatWithMetaData),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
         ]
     }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -450,7 +450,7 @@ class LoggingTest: XCTestCase {
         XCTAssertTrue(messageSucceeded ?? false)
         XCTAssertEqual(interceptStream.strings.count, 1)
     }
-    
+
     func testStreamLogHandlerOutputFormat() {
         let interceptStream = InterceptStream()
         let label = "testLabel"
@@ -461,16 +461,15 @@ class LoggingTest: XCTestCase {
 
         let testString = "my message is better than yours"
         log.critical("\(testString)")
-        
+
         let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\(testString)$"
 
         let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
-        
 
         XCTAssertTrue(messageSucceeded)
         XCTAssertEqual(interceptStream.strings.count, 1)
     }
-    
+
     func testStreamLogHandlerOutputFormatWithMetaData() {
         let interceptStream = InterceptStream()
         let label = "testLabel"
@@ -481,11 +480,10 @@ class LoggingTest: XCTestCase {
 
         let testString = "my message is better than yours"
         log.critical("\(testString)", metadata: ["test": "test"])
-        
+
         let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\(testString)$"
 
         let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
-        
 
         XCTAssertTrue(messageSucceeded)
         XCTAssertEqual(interceptStream.strings.count, 1)

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -450,6 +450,46 @@ class LoggingTest: XCTestCase {
         XCTAssertTrue(messageSucceeded ?? false)
         XCTAssertEqual(interceptStream.strings.count, 1)
     }
+    
+    func testStreamLogHandlerOutputFormat() {
+        let interceptStream = InterceptStream()
+        let label = "testLabel"
+        LoggingSystem.bootstrapInternal { _ in
+            StreamLogHandler(label: label, stream: interceptStream)
+        }
+        let log = Logger(label: label)
+
+        let testString = "my message is better than yours"
+        log.critical("\(testString)")
+        
+        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\(testString)$"
+
+        let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
+        
+
+        XCTAssertTrue(messageSucceeded)
+        XCTAssertEqual(interceptStream.strings.count, 1)
+    }
+    
+    func testStreamLogHandlerOutputFormatWithMetaData() {
+        let interceptStream = InterceptStream()
+        let label = "testLabel"
+        LoggingSystem.bootstrapInternal { _ in
+            StreamLogHandler(label: label, stream: interceptStream)
+        }
+        let log = Logger(label: label)
+
+        let testString = "my message is better than yours"
+        log.critical("\(testString)", metadata: ["test": "test"])
+        
+        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\(testString)$"
+
+        let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
+        
+
+        XCTAssertTrue(messageSucceeded)
+        XCTAssertEqual(interceptStream.strings.count, 1)
+    }
 
     func testStdioOutputStreamFlush() {
         // flush on every statement


### PR DESCRIPTION
`StreamLogHandler` now includes `label` in the log output

### Motivation:

In my opinion, It's the most basic feature missing even for a test `LogHandler`. More details here https://github.com/apple/swift-log/issues/57

### Modifications:

Store the `label` in `StreamLogHandler` which was previously ignored don't know the rationale behind it. Since it's mandatory to pass a label at the time of initialization it makes sense to store it. Finally, include it in the log output right after the log level.

### Result:

`StreamLogHandler` will include `label` in the log output and resolves #57 

Sample output:- 

Before: `2019-12-15T17:09:32-0600 info: info`
After: `2019-12-15T17:09:32-0600 info test : info`
