### PR TITLE
Fix small typo in tests

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -32,7 +32,7 @@ class LoggingTest: XCTestCase {
             XCTFail("trace should not be called")
             return "trace"
         }())
-        logger.debug({
+        logger.trace({
             XCTFail("trace should not be called")
             return "trace"
         }())

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -29,8 +29,8 @@ class LoggingTest: XCTestCase {
         var logger = Logger(label: "test")
         logger.logLevel = .info
         logger.log(level: .debug, {
-            XCTFail("trace should not be called")
-            return "trace"
+            XCTFail("debug should not be called")
+            return "debug"
         }())
         logger.trace({
             XCTFail("trace should not be called")


### PR DESCRIPTION
### Motivation:

I just checked the tests and noticed that it should test `trace` and not `debug`.
