### PR TITLE
test that demonstrates overloading

### DIFF
--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -45,6 +45,7 @@ extension LoggingTest {
             ("testStreamLogHandlerOutputFormat", testStreamLogHandlerOutputFormat),
             ("testStreamLogHandlerOutputFormatWithMetaData", testStreamLogHandlerOutputFormatWithMetaData),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
+            ("testOverloadingError", testOverloadingError),
         ]
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -550,4 +550,29 @@ class LoggingTest: XCTestCase {
 
         fds.forEach { close($0) }
     }
+
+    func testOverloadingError() {
+        struct Dummy: Error, LocalizedError {
+            var errorDescription: String? {
+                return "errorDescription"
+            }
+        }
+        // bootstrap with our test logging impl
+        let logging = TestLogging()
+        LoggingSystem.bootstrapInternal(logging.make)
+
+        var logger = Logger(label: "test")
+        logger.logLevel = .error
+        logger.error(Dummy())
+
+        logging.history.assertExist(level: .error, message: "errorDescription")
+    }
+}
+
+extension Logger {
+    public func error(_ error: Error,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #file, function: String = #function, line: UInt = #line) {
+        self.error("\(error.localizedDescription)", metadata: metadata(), file: file, function: function, line: line)
+    }
 }


### PR DESCRIPTION
Motivation:

SwiftLog is meant as a base logging library so users will often overload
certain functions with their own specialised and opinionated overloads.

Modification:

Add a test as demonstration.

Result:

More tests.