### PR TITLE
Add NSHipster/swift-log-github-actions to list of backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [vapor/console-kit](https://github.com/vapor/console-kit/) | print log messages to a terminal with stylized ([ANSI](https://en.wikipedia.org/wiki/ANSI_escape_code)) output |
 | [neallester/swift-log-testing](https://github.com/neallester/swift-log-testing) | provides access to log messages for use in assertions (within test targets) | 
 | [wlisac/swift-log-slack](https://github.com/wlisac/swift-log-slack)  | a logging backend that sends critical log messages to Slack |
+| [NSHipster/swift-log-github-actions](https://github.com/NSHipster/swift-log-github-actions) | a logging backend that translates logging messages into [workflow commands for GitHub Actions](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions). |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Updates the list of `SwiftLog` backend implementations to include [swift-log-github-actions](https://github.com/NSHipster/swift-log-github-actions).

### Motivation:

In the development of [SwiftDoc](https://github.com/SwiftDocOrg/swift-doc) and other libraries, I've made extensive use of [GitHub Actions](https://github.com/features/actions) for CI/CD. When executing Swift code in this context, I wanted an easy way to opt-in to [workflow commands](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions), which, for example, allow errors to be surfaced in GitHub's UI like this:

<img width="636" alt="github-actions-ui" src="https://user-images.githubusercontent.com/7659/77639069-5cca9c80-6f15-11ea-927e-a3e92d0018d6.png">

I thought that this functionality might be useful for anyone else developing on GitHub's infrastructure, and wanted to share it here for greater visibility.

### Modifications:

Appended `NSHipster/swift-log-github-actions` to the list of implementations in the README.

### Result:

This PR makes no changes to code, just the README.
