### PR TITLE
Add easy link to backends section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ LoggingSystem.bootstrap(StreamLogHandler.standardError)
 
 For further information, please check the [API documentation][api-docs].
 
-#### Backends
+#### Selecting a logging backend implementation (applications only)
+<a name="backends"></a>
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ LoggingSystem.bootstrap(StreamLogHandler.standardError)
 
 For further information, please check the [API documentation][api-docs].
 
-#### Selecting a logging backend implementation (applications only)
+#### Backends
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ LoggingSystem.bootstrap(StreamLogHandler.standardError)
 
 For further information, please check the [API documentation][api-docs].
 
-#### Selecting a logging backend implementation (applications only)
 <a name="backends"></a>
+#### Selecting a logging backend implementation (applications only)
 
 As the API has just launched, not many implementations exist yet. If you are interested in implementing one see the "Implementation considerations" section below explaining how to do so. List of existing SwiftLog API compatible libraries:
 


### PR DESCRIPTION
I want to link to a list of SwiftLog's supported backends from various places. Currently the link is verbose and probably fragile:

https://github.com/apple/swift-log#selecting-a-logging-backend-implementation-applications-only

I propose making the link simply `#backends` which is more concise and will be easier to maintain going forward. 