### PR TITLE
Updates the docstring for the 'trace' log level

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -323,7 +323,8 @@ extension Logger {
     /// Log levels are ordered by their severity, with `.trace` being the least severe and
     /// `.critical` being the most severe.
     public enum Level: String, Codable, CaseIterable {
-        /// Appropriate for messages that contain information only when debugging a program.
+        /// Appropriate for messages that contain information normally of use only when
+        /// tracing the execution of a program.
         case trace
 
         /// Appropriate for messages that contain information normally of use only when


### PR DESCRIPTION
Motivation:

The current docstring seems to be missing some words that indicate
when a 'trace' log level is more appropriate than a 'debug' log
level. This was brought up in https://github.com/vapor/docs/issues/463
and has been fixed there. This PR is being submitted to the upstream
project as a courtesy.

Modifications:

This PR adds a clause to the docstring of the 'trace' log level to
clearly indicate when this log level shuld be used.

Result:

The docstring for the 'trace' log level will mirror the structure of
the docstring for the 'debug' log level, but will include a clear
opinion of when the 'trace' log level is appropriate.

Signed-off-by: zach wick <zach@zachwick.com>