### PR TITLE
Add swift-log-datadog to list of backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [wlisac/swift-log-slack](https://github.com/wlisac/swift-log-slack)  | a logging backend that sends critical log messages to Slack |
 | [NSHipster/swift-log-github-actions](https://github.com/NSHipster/swift-log-github-actions) | a logging backend that translates logging messages into [workflow commands for GitHub Actions](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions). |
 | [stevapple/swift-log-telegram](https://github.com/stevapple/swift-log-telegram) | a logging backend that sends log messages to any Telegram chat (Inspired by and forked from [wlisac/swift-log-slack](https://github.com/wlisac/swift-log-slack)) |
+| [jagreenwood/swift-log-datadog](https://github.com/jagreenwood/swift-log-datadog)  | a logging backend which sends log messages to the [Datadog](https://www.datadoghq.com/log-management/) log management service |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Appends `jagreenwood/swift-log-datadog` to list of implementations

### Motivation:

I thought it would be useful to build a swift-log handler for the [Datadog](https://www.datadoghq.com) log system. This PR seeks to share this with others by adding a link to the backend implementations.

### Modifications:

Appended jagreenwood/swift-log-datadog to the list of implementations in the README.

### Result:

This PR makes no changes to code, just the README.
