### PR TITLE
silence #file to #filePath warnings

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -11,3 +11,5 @@
 --ifdef no-indent
 
 # rules
+
+--disable redundantParens # https://github.com/nicklockwood/SwiftFormat/issues/638

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -152,7 +152,7 @@ class LoggingTest: XCTestCase {
                                                    "lazy": .stringConvertible(LazyMetadataBox { "rendered-at-first-use" })])
     }
 
-    private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> Logger.Message {
+    private func dontEvaluateThisString(file: StaticString = (#file), line: UInt = #line) -> Logger.Message {
         XCTFail("should not have been evaluated", file: file, line: line)
         return "should not have been evaluated"
     }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -173,12 +173,20 @@ internal struct LogEntry {
 }
 
 extension History {
-    func assertExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, file: StaticString = #file, line: UInt = #line) {
+    func assertExist(level: Logger.Level,
+                     message: String,
+                     metadata: Logger.Metadata? = nil,
+                     file: StaticString = (#file),
+                     line: UInt = #line) {
         let entry = self.find(level: level, message: message, metadata: metadata)
         XCTAssertNotNil(entry, "entry not found: \(level), \(String(describing: metadata)), \(message) ", file: file, line: line)
     }
 
-    func assertNotExist(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, file: StaticString = #file, line: UInt = #line) {
+    func assertNotExist(level: Logger.Level,
+                        message: String,
+                        metadata: Logger.Metadata? = nil,
+                        file: StaticString = (#file),
+                        line: UInt = #line) {
         let entry = self.find(level: level, message: message, metadata: metadata)
         XCTAssertNil(entry, "entry was found: \(level), \(String(describing: metadata)), \(message)", file: file, line: line)
     }


### PR DESCRIPTION
    Motivation:
    
    Swift 5.3 will keep `#file` == `#filePath` but starts warning if you
    pass `#file` to an argument that's `#filePath` defaulted (XCTest).
    
    Modification:
    
    - Replace `#file` with `(#file)` to silence the warning. In Swift 5.3
      `#file` == `#filePath`.
    
    Result:
    
    No warnings