### PR TITLE
Fix doc typo

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -258,7 +258,7 @@ public enum LoggingSystem {
 
     /// `bootstrap` is a one-time configuration function which globally selects the desired logging backend
     /// implementation. `bootstrap` can be called at maximum once in any given program, calling it more than once will
-    /// lead to undefined behaviour, most likely a crash.
+    /// lead to undefined behavior, most likely a crash.
     ///
     /// - parameters:
     ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -291,7 +291,7 @@ extension Logger {
     /// Examples:
     ///  - prefer `logger.info("user logged in", metadata: ["user-id": "\(user.id)"])` over
     ///    `..., metadata: ["user-id": .string(user.id.description)])`
-    ///  - prefer `logger.info("user selected colours", metadata: ["colors": ["\(user.topColor)", "\(user.secondColor)"]])`
+    ///  - prefer `logger.info("user selected colors", metadata: ["colors": ["\(user.topColor)", "\(user.secondColor)"]])`
     ///    over `..., metadata: ["colors": .array([.string("\(user.topColor)"), .string("\(user.secondColor)")])`
     ///  - prefer `logger.info("nested info", metadata: ["nested": ["fave-numbers": ["\(1)", "\(2)", "\(3)"], "foo": "bar"]])`
     ///    over `..., metadata: ["nested": .dictionary(["fave-numbers": ...])])`


### PR DESCRIPTION
Fix typo in `MetadataValue` and `LoggingSystem` words in docs

### Motivation:

I found some words spelling in British English, I know they are both **correct**, but I would prefer keeping the consistency with other parts in the same docs.

Such as line 292

> ///  - prefer `logger.info("user selected colours", metadata: ["colors": ["\(user.topColor)", "\(user.secondColor)"]])`

It uses `color` other than the first one.

### Modifications:

Fix typos in `Logging.swift`.

### Result:

This PR makes no changes to code, just the docs.
