### PR TITLE
forward #file to #filePath differently

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -152,8 +152,8 @@ class LoggingTest: XCTestCase {
                                                    "lazy": .stringConvertible(LazyMetadataBox { "rendered-at-first-use" })])
     }
 
-    private func dontEvaluateThisString(file: StaticString = (#file), line: UInt = #line) -> Logger.Message {
-        XCTFail("should not have been evaluated", file: file, line: line)
+    private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> Logger.Message {
+        XCTFail("should not have been evaluated", file: (file), line: line)
         return "should not have been evaluated"
     }
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -176,19 +176,21 @@ extension History {
     func assertExist(level: Logger.Level,
                      message: String,
                      metadata: Logger.Metadata? = nil,
-                     file: StaticString = (#file),
+                     file: StaticString = #file,
                      line: UInt = #line) {
         let entry = self.find(level: level, message: message, metadata: metadata)
-        XCTAssertNotNil(entry, "entry not found: \(level), \(String(describing: metadata)), \(message) ", file: file, line: line)
+        XCTAssertNotNil(entry, "entry not found: \(level), \(String(describing: metadata)), \(message) ",
+                        file: (file), line: line)
     }
 
     func assertNotExist(level: Logger.Level,
                         message: String,
                         metadata: Logger.Metadata? = nil,
-                        file: StaticString = (#file),
+                        file: StaticString = #file,
                         line: UInt = #line) {
         let entry = self.find(level: level, message: message, metadata: metadata)
-        XCTAssertNil(entry, "entry was found: \(level), \(String(describing: metadata)), \(message)", file: file, line: line)
+        XCTAssertNil(entry, "entry was found: \(level), \(String(describing: metadata)), \(message)",
+                     file: (file), line: line)
     }
 
     func find(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil) -> LogEntry? {


### PR DESCRIPTION
Motivation:

only works if done when _calling_ a function, not when defining one :|.

- https://github.com/apple/swift/pull/32445
- https://bugs.swift.org/browse/SR-12936
- https://bugs.swift.org/browse/SR-12934
- https://bugs.swift.org/browse/SR-13041

Modifications:

Silence #file to #filePath differently.

Result:

Hopefully at some point we get this working.