### PR TITLE
Improvements to `Lock` and `ReadWriteLock`

### DIFF
--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -55,8 +55,8 @@ internal final class Lock {
         InitializeSRWLock(self.mutex)
         #else
         var attr = pthread_mutexattr_t()
-        pthread_mutexattr_init(&attr);
-        pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK));
+        pthread_mutexattr_init(&attr)
+        pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK))
 
         let err = pthread_mutex_init(self.mutex, &attr)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -182,7 +182,7 @@ internal final class ReadWriteLock {
     public func lockWrite() {
         #if os(Windows)
         AcquireSRWLockExclusive(self.rwlock)
-        self.shared = true
+        self.shared = false
         #else
         let err = pthread_rwlock_wrlock(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -54,7 +54,11 @@ internal final class Lock {
         #if os(Windows)
         InitializeSRWLock(self.mutex)
         #else
-        let err = pthread_mutex_init(self.mutex, nil)
+        var attr = pthread_mutexattr_t()
+        pthread_mutexattr_init(&attr);
+        pthread_mutexattr_settype(&attr, .init(PTHREAD_MUTEX_ERRORCHECK));
+
+        let err = pthread_mutex_init(self.mutex, &attr)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
     }

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -55,7 +55,7 @@ internal final class Lock {
         InitializeSRWLock(self.mutex)
         #else
         let err = pthread_mutex_init(self.mutex, nil)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
     }
 
@@ -64,7 +64,7 @@ internal final class Lock {
         // SRWLOCK does not need to be free'd
         #else
         let err = pthread_mutex_destroy(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
         self.mutex.deallocate()
     }
@@ -78,7 +78,7 @@ internal final class Lock {
         AcquireSRWLockExclusive(self.mutex)
         #else
         let err = pthread_mutex_lock(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
     }
 
@@ -91,7 +91,7 @@ internal final class Lock {
         ReleaseSRWLockExclusive(self.mutex)
         #else
         let err = pthread_mutex_unlock(self.mutex)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
         #endif
     }
 }
@@ -143,7 +143,7 @@ internal final class ReadWriteLock {
         InitializeSRWLock(self.rwlock)
         #else
         let err = pthread_rwlock_init(self.rwlock, nil)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
         #endif
     }
 
@@ -152,7 +152,7 @@ internal final class ReadWriteLock {
         // SRWLOCK does not need to be free'd
         #else
         let err = pthread_rwlock_destroy(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
         #endif
         self.rwlock.deallocate()
     }
@@ -167,7 +167,7 @@ internal final class ReadWriteLock {
         self.shared = true
         #else
         let err = pthread_rwlock_rdlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
         #endif
     }
 
@@ -181,7 +181,7 @@ internal final class ReadWriteLock {
         self.shared = true
         #else
         let err = pthread_rwlock_wrlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
         #endif
     }
 
@@ -199,7 +199,7 @@ internal final class ReadWriteLock {
         }
         #else
         let err = pthread_rwlock_unlock(self.rwlock)
-        precondition(err == 0)
+        precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
         #endif
     }
 }


### PR DESCRIPTION
Correct inaccurate comments on `Lock` and `ReadWriteLock`, port improved implementation behaviors from NIO for `Lock`, and fix a Windows implementation bug in `ReadWriteLock`

### Motivation:

- The documentation comments were obviously incorrect for `ReadWriteLock`, being simply copies of those for `Lock`.
- NIO added `PTHREAD_MUTEX_ERRORCHECK` to its implementation of `Lock`, an obvious safety measure with surprisingly little performance impact, especially on Ubuntu Focal.
- The `precondition()` checks for `pthread` API failures are much clearer when specific error messages are included.
- The Windows implementation of `ReadWriteLock` was incorrectly recording the `SRWLOCK` mode as shared (reader) even when it was exclusive (writer), leading to an API usage violation.

### Modifications:

- Updated the documentation comments for `ReadWriteLock` to refer to the correct functionality and method names.
- Copied the improvements to `Lock` and the `precondition()` checks from NIO.
- Fixed the Windows implementation bug.

### Result:

- Errors emitted by `pthread` APIs will now have more specific error messages.
- The `pthread` APIs used by `Lock` will now detect misuse.
- The Windows implementation of `ReadWriteLock` will now call the appropriate release function.