### PR TITLE
Add NoOpLogHandler for when you don't want logging

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -646,23 +646,23 @@ public struct StreamLogHandler: LogHandler {
 
 /// No operation LogHandler, used when no logging is required
 public struct NoOpLogHandler: LogHandler {
-    public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
+    @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
 
-    public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
+    @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
         get {
             return nil
         }
         set {}
     }
 
-    public var metadata: Logger.Metadata {
+    @inlinable public var metadata: Logger.Metadata {
         get {
             return [:]
         }
         set {}
     }
 
-    public var logLevel: Logger.Level {
+    @inlinable public var logLevel: Logger.Level {
         get {
             return .critical
         }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -645,7 +645,7 @@ public struct StreamLogHandler: LogHandler {
 }
 
 /// No operation LogHandler, used when no logging is required
-public struct NoOpLogHandler: LogHandler {
+public struct SwiftLogNoOpLogHandler: LogHandler {
     @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
 
     @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -644,6 +644,32 @@ public struct StreamLogHandler: LogHandler {
     }
 }
 
+/// No operation LogHandler, used when no logging is required
+public struct NoOpLogHandler: LogHandler {
+    public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
+
+    public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
+        get {
+            return nil
+        }
+        set {}
+    }
+
+    public var metadata: Logger.Metadata {
+        get {
+            return [:]
+        }
+        set {}
+    }
+
+    public var logLevel: Logger.Level {
+        get {
+            return .critical
+        }
+        set {}
+    }
+}
+
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
 // https://bugs.swift.org/browse/SR-9686
 extension Logger.MetadataValue: ExpressibleByStringLiteral {


### PR DESCRIPTION
_[One line description of your change]_

Provider a LogHandler that outputs nothing

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

I've just started looking into adding logging to aws-sdk-swift and I've found I am going to be replicating the `NoOpLogHandler` from async-http-client in aws-sdk-swift-core. It's a small bit of code but I think worthwhile to bring into swift-log to avoid multiple systems replicating this functionality when they want to provide a no logging option.  

_[Describe the modifications you've done.]_

Add struct `NoOpLogHandler` which conforms to `LogHandler` and implements all the methods as empty functions.

_[After your change, what will change.]_

Systems will be able to provide a no logging option, without having to test against an optional `Logger`.