### PR TITLE
Sort metadata by keys when prettifying

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -715,7 +715,9 @@ public struct StreamLogHandler: LogHandler {
     }
 
     private func prettify(_ metadata: Logger.Metadata) -> String? {
-        return !metadata.isEmpty ? metadata.map { "\($0)=\($1)" }.joined(separator: " ") : nil
+        return !metadata.isEmpty
+            ? metadata.lazy.sorted(by: { $0.key < $1.key }).map { "\($0)=\($1)" }.joined(separator: " ")
+            : nil
     }
 
     private func timestamp() -> String {

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -48,6 +48,7 @@ extension LoggingTest {
             ("testStreamLogHandlerWritesToAStream", testStreamLogHandlerWritesToAStream),
             ("testStreamLogHandlerOutputFormat", testStreamLogHandlerOutputFormat),
             ("testStreamLogHandlerOutputFormatWithMetaData", testStreamLogHandlerOutputFormatWithMetaData),
+            ("testStreamLogHandlerOutputFormatWithOrderedMetadata", testStreamLogHandlerOutputFormatWithOrderedMetadata),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
             ("testOverloadingError", testOverloadingError),
         ]

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -637,6 +637,28 @@ class LoggingTest: XCTestCase {
         XCTAssertEqual(interceptStream.strings.count, 1)
     }
 
+    func testStreamLogHandlerOutputFormatWithOrderedMetadata() {
+        let interceptStream = InterceptStream()
+        let label = "testLabel"
+        LoggingSystem.bootstrapInternal { _ in
+            StreamLogHandler(label: label, stream: interceptStream)
+        }
+        let log = Logger(label: label)
+
+        let testString = "my message is better than yours"
+        log.critical("\(testString)", metadata: ["a": "a0", "b": "b0"])
+        log.critical("\(testString)", metadata: ["b": "b1", "a": "a1"])
+
+        XCTAssertEqual(interceptStream.strings.count, 2)
+        guard interceptStream.strings.count == 2 else {
+            XCTFail("Intercepted \(interceptStream.strings.count) logs, expected 2")
+            return
+        }
+
+        XCTAssert(interceptStream.strings[0].contains("a=a0 b=b0"))
+        XCTAssert(interceptStream.strings[1].contains("a=a1 b=b1"))
+    }
+
     func testStdioOutputStreamFlush() {
         // flush on every statement
         self.withWriteReadFDsAndReadBuffer { writeFD, readFD, readBuffer in


### PR DESCRIPTION
Motivation:

The stream log handler doesn't print metadata in a stable order. While
swift-log is an API package and shouldn't provide all the bells and
whistles for formatting logs, it should make the default log handler
at least somewhat sensible.

Modifications:

- Sort the metadata by key when 'prettifying' it

Result:

- The stream log handler emits logs with metadata in a stable order
- Resolves #128