### PR TITLE
Make it possible to configure `LogHandler`s when creating `Logger`s

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -430,7 +430,7 @@ extension Logger {
     public init(label: String, factory: (String) -> LogHandler) {
         self = Logger(label: label, factory(label))
     }
-    
+
     /// Construct a `Logger` given a `label` identifying the creator of the `Logger` and configuring the instantiated
     /// log handler before using it.
     ///
@@ -445,7 +445,7 @@ extension Logger {
     /// metadata, and allows specialized `LogHandler`s to be individually configurable.
     public init(label: String, configuringWith handlerConfigurator: (inout LogHandler) -> Void) {
         self = LoggingSystem.lock.withReaderLock {
-            return Logger(label: label, factory: { label in
+            Logger(label: label, factory: { label in
                 var handler = LoggingSystem.factory(label)
                 handlerConfigurator(&handler)
                 return handler

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -37,6 +37,7 @@ extension LoggingTest {
             ("testAutoClosuresAreNotForcedUnlessNeeded", testAutoClosuresAreNotForcedUnlessNeeded),
             ("testLocalMetadata", testLocalMetadata),
             ("testCustomFactory", testCustomFactory),
+            ("testConfiguringFactory", testConfiguringFactory),
             ("testAllLogLevelsExceptCriticalCanBeBlocked", testAllLogLevelsExceptCriticalCanBeBlocked),
             ("testAllLogLevelsWork", testAllLogLevelsWork),
             ("testLogMessageWithStringInterpolation", testLogMessageWithStringInterpolation),

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -359,6 +359,23 @@ class LoggingTest: XCTestCase {
         let logger2 = Logger(label: "foo", factory: { _ in CustomHandler() })
         XCTAssertTrue(logger2.handler is CustomHandler, "expected custom log handler")
     }
+    
+    func testConfiguringFactory() {
+        struct CustomHandler: LogHandler {
+            func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {}
+            subscript(metadataKey _: String) -> Logger.Metadata.Value? { get { nil } set {} }
+            var metadata: Logger.Metadata { get { .init() } set {} }
+            var logLevel: Logger.Level = .info
+        }
+        LoggingSystem.bootstrapInternal { _ in CustomHandler() }
+        
+        let logger1 = Logger(label: "foo")
+        XCTAssertTrue(logger1.handler is CustomHandler, "expected custom log handler")
+        XCTAssertEqual(logger1.handler.logLevel, .info, "expected default log level")
+        let logger2 = Logger(label: "foo", configuringWith: { handler in handler.logLevel = .notice })
+        XCTAssertTrue(logger2.handler is CustomHandler, "expected custom log handler")
+        XCTAssertEqual(logger2.handler.logLevel, .notice, "expected custom log level")
+    }
 
     func testAllLogLevelsExceptCriticalCanBeBlocked() {
         let testLogging = TestLogging()

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -363,8 +363,8 @@ class LoggingTest: XCTestCase {
     func testConfiguringFactory() {
         struct CustomHandler: LogHandler {
             func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {}
-            subscript(metadataKey _: String) -> Logger.Metadata.Value? { get { nil } set {} }
-            var metadata: Logger.Metadata { get { .init() } set {} }
+            subscript(metadataKey _: String) -> Logger.Metadata.Value? { get { return nil } set {} }
+            var metadata: Logger.Metadata { get { return .init() } set {} }
             var logLevel: Logger.Level = .info
         }
         LoggingSystem.bootstrapInternal { _ in CustomHandler() }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -359,7 +359,7 @@ class LoggingTest: XCTestCase {
         let logger2 = Logger(label: "foo", factory: { _ in CustomHandler() })
         XCTAssertTrue(logger2.handler is CustomHandler, "expected custom log handler")
     }
-    
+
     func testConfiguringFactory() {
         struct CustomHandler: LogHandler {
             func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {}
@@ -368,7 +368,7 @@ class LoggingTest: XCTestCase {
             var logLevel: Logger.Level = .info
         }
         LoggingSystem.bootstrapInternal { _ in CustomHandler() }
-        
+
         let logger1 = Logger(label: "foo")
         XCTAssertTrue(logger1.handler is CustomHandler, "expected custom log handler")
         XCTAssertEqual(logger1.handler.logLevel, .info, "expected default log level")


### PR DESCRIPTION
It is now possible to supply additional configuration to a `Logger`'s `LogHandler` without having to specify an entire handler factory.

### Motivation:

It is sometimes desirable to configure a new `Logger`'s `LogHandler` specially for the particular `Logger` (such as by changing its handler-specific metadata). Currently, the only way to accomplish this is to provide a new handler factory which creates a new `LogHandler`, with no reference to the default handler type that was used to bootstrap the logging system. This means that library code wishing to provide specialized logging for itself must currently hardcode use of, e.g., `StreamLogHandler` instead of configuring whichever handler the app using the library bootstrapped.

### Modifications:

A new initializer for `Logger` has been added which accepts a configuration closure; this closure is provided the `LogHandler` which will be used by the new `Logger`, and may modify it as needed.

### Result:

Code such as this:

```swift
// calling app has configured, e.g., a typical `MultiplexLogHandler`
let logger = Logger(label: "something-something-dark-side", factory: { label in
    // oh well, forced to use the wrong handler, hope the app doesn't mind
    var handler = HypotheticalLogHandler.standardOutput(label: label)
    handler.hoardsKrendars = true
    return handler
})
```

can now instead be written in this fashion:

```swift
// calling app might have configured a multiplex handler, or it might not have
let logger = Logger(label: "something-something-dark-side", configuringWith: { handler in
    guard handler is HypotheticalLogHandler else { return }
    (handler as! HypotheticalLogHandler).hoardsKrendars = true // can't assign through `as?`
})
```
