### PR TITLE
Make Logger.Metadata.Key strongly typed

### DIFF
--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -146,6 +146,11 @@ public protocol LogHandler {
     ///
     /// - parameters:
     ///    - metadataKey: The key for the metadata item
+    subscript(metadataKey _: Logger.Metadata.Key) -> Logger.Metadata.Value? { get set }
+
+    /// SwiftLog 1.4 compatibility method. Please do _not_ implement, implement
+    /// the subscript that uses `Logger.Metadata.Key` instead.
+    @available(*, deprecated, message: "Please use `Logger.Metadata.Key` instead of String-based keys")
     subscript(metadataKey _: String) -> Logger.Metadata.Value? { get set }
 
     /// Get or set the entire metadata storage as a dictionary.
@@ -184,5 +189,17 @@ extension LogHandler {
                  file: file,
                  function: function,
                  line: line)
+    }
+
+    @available(*, deprecated, message: "You should implement this subscript instead of using the default implementation")
+    public subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
+        get { self[metadataKey: metadataKey.rawValue] }
+        set { self[metadataKey: metadataKey.rawValue] = newValue }
+    }
+
+    @available(*, deprecated, message: "Please use `Logger.Metadata.Key` instead of String-based keys")
+    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get { self[metadataKey: .init(rawValue: metadataKey)] }
+        set { self[metadataKey: .init(rawValue: metadataKey)] = newValue }
     }
 }

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -70,7 +70,7 @@ private struct OldSchoolLogHandler: LogHandler {
         self.recorder.record(level: level, metadata: metadata, message: message, source: "no source")
     }
 
-    subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+    subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
         get {
             return self.metadata[metadataKey]
         }

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -83,7 +83,7 @@ private struct Context {
     }
 
     // since logger is a value type, we can reuse our copy to manage metadata
-    subscript(metadataKey: String) -> Logger.Metadata.Value? {
+    subscript(metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
         get { return self.logger[metadataKey: metadataKey] }
         set { self.logger[metadataKey: metadataKey] = newValue }
     }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -258,6 +258,17 @@ class LoggingTest: XCTestCase {
                                                    "nested-list": ["l1str", ["l2str1", "l2str2"]]])
     }
 
+    func testMetadataKeyLiteralConformances() {
+        let key1: Logger.Metadata.Key = "abc"
+        let key2: Logger.Metadata.Key = "\(key1)def"
+        let key3: Logger.Metadata.Key = .init("ghi")
+        let key4: Logger.Metadata.Key = .init(rawValue: "jkl")
+        XCTAssertEqual(key1.rawValue, "abc")
+        XCTAssertEqual(key2.rawValue, "abcdef")
+        XCTAssertEqual(key3.rawValue, "ghi")
+        XCTAssertEqual(key4.rawValue, "jkl")
+    }
+
     // Example of custom "box" which may be used to implement "render at most once" semantics
     // Not thread-safe, thus should not be shared across threads.
     internal class LazyMetadataBox: CustomStringConvertible {
@@ -496,7 +507,7 @@ class LoggingTest: XCTestCase {
                 self.recorder.record(level: level, metadata: metadata, message: message, source: source)
             }
 
-            subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+            subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
                 get {
                     return self.metadata[metadataKey]
                 }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -216,7 +216,7 @@ public class MDC {
 
     private init() {}
 
-    public subscript(metadataKey: String) -> Logger.Metadata.Value? {
+    public subscript(metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
         get {
             return self.lock.withLock {
                 self.storage[self.threadId]?[metadataKey]


### PR DESCRIPTION
Make `Logger.Metadata.Key` strongly typed by using a separate struct.

### Motivation:

Using `String` as keys makes it hard to use constants for metadata keys. They have to be defined in some arbitrary namespace. Or if they don't, they're messy to change and even harder to "look up" (e.g. what keys exist on that logger? what key stores what information) since there is no central definition place.

```swift
enum SomeMetadataKeyNamespace {
    static let myMetadataKey = "awesome-key"
}

var logger = Logger(label: "some.great.logger")
logger[metadataKey: SomeMetadataKeyNamespace. myMetadataKey] = "what a beautiful value"

// Later on in e.g. a different file (a `LogHandler` implementation for example)
if case .string(let str)? = logger[metadataKey: SomeMetadataKeyNamespace. myMetadataKey], str.contains("beautiful") {
    print("It's beautiful!")
} else {
    print("Not beautiful...")
}
```

### Modifications:

- Add `Logger.MetadataKey` and change the `typealias` for `Logger.Metadata` to use `Logger.MetadataKey` as key instead of String.
- Change the protocol requirement in `LogHandler` to take `Logger.Metadata.Key` instead of `String` in `subscript(metadataKey:)`.
- `Logger.MetadataKey` conforms to:
    - `RawRepresentable` (`RawValue = String`)
    - `Hashable`
    - `CustomStringConvertible` (`description` being `rawValue`)
    - `ExpressibleByStringLiteral` (`StringLiteralType = String`)
    - `ExpressibleByStringInterpolation` (`StringInterpolation` = `DefaultStringInterpolation`)

### Result:

Using a separate struct for `Logger.Metadata.Key` allows static constants on it making metadata "nicer" to use:

```swift
extension Logger.Metadata.Key {
     static let myMetadataKey = Logger.Metadata.Key(rawValue: "awesome-key")
}

var logger = Logger(label: "some.great.logger")
logger[metadataKey: .myMetadataKey] = "what a beautiful value"

// Later on in e.g. a different file (a `LogHandler` implementation for example)
if case .string(let str)? = logger[metadataKey: .myMetadataKey], str.contains("beautiful") {
    print("It's beautiful!")
} else {
    print("Not beautiful...")
}
```



###  Source Compatibility
I'm not sure this change can be made in a source compatible way - especially since the `subscript(metadataKey:)` was directly requiring `String` instead of `Logger.Metadata.Key`. Most implementations would probably be fine with the deprecated overload I added (similar than what has been done for `source` - although I've read that this wasn't perfect either). But those implementations that use `String` APIs will definitively break. Thus this will likely need a new major version - in which case I could remove the "attempted backwards compatibility" 🙂 