### PR TITLE
Update metadata formatting for readability

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -711,12 +711,12 @@ public struct StreamLogHandler: LogHandler {
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
         var stream = self.stream
-        stream.write("\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") \(message)\n")
+        stream.write("\(self.timestamp()) \(level) \(self.label) : \(message)\n\(prettyMetadata.map { "\t\($0)\n" } ?? "\n")")
     }
 
     private func prettify(_ metadata: Logger.Metadata) -> String? {
         return !metadata.isEmpty
-            ? metadata.lazy.sorted(by: { $0.key < $1.key }).map { "\($0)=\($1)" }.joined(separator: " ")
+            ? metadata.lazy.sorted(by: { $0.key < $1.key }).map { "\($0)=\($1)" }.joined(separator: "\n\t")
             : nil
     }
 

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -629,9 +629,9 @@ class LoggingTest: XCTestCase {
         let testString = "my message is better than yours"
         log.critical("\(testString)", metadata: ["test": "test"])
 
-        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\(testString)$"
+        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\(testString)\\n\\stest=test\\n"
 
-        let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
+        let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespaces).range(of: pattern, options: .regularExpression) != nil
 
         XCTAssertTrue(messageSucceeded)
         XCTAssertEqual(interceptStream.strings.count, 1)
@@ -655,8 +655,8 @@ class LoggingTest: XCTestCase {
             return
         }
 
-        XCTAssert(interceptStream.strings[0].contains("a=a0 b=b0"))
-        XCTAssert(interceptStream.strings[1].contains("a=a1 b=b1"))
+        XCTAssert(interceptStream.strings[0].contains("a=a0\n\tb=b0"))
+        XCTAssert(interceptStream.strings[1].contains("a=a1\n\tb=b1"))
     }
 
     func testStdioOutputStreamFlush() {


### PR DESCRIPTION
Motivation:

For packages that generate logs and use them as part of the development process,
it is beneficial to be able to read through logs without having to write custom
log handlers or pull in a dependency for formatting only at dev time.

Modifications:

- Change: The format of `StreamLogHandler` to output metadata on newlines with tab indentation

Result:

Package authors will have an easier time debugging their applications without boilerplate code or dependencies.

This resolves #162