### PR TITLE
Logging: repair the Windows build after MSVCRT rename

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -15,7 +15,7 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin
 #elseif os(Windows)
-import MSVCRT
+import CRT
 #else
 import Glibc
 #endif
@@ -652,8 +652,8 @@ internal struct StdioOutputStream: TextOutputStream {
 let systemStderr = Darwin.stderr
 let systemStdout = Darwin.stdout
 #elseif os(Windows)
-let systemStderr = MSVCRT.stderr
-let systemStdout = MSVCRT.stdout
+let systemStderr = CRT.stderr
+let systemStdout = CRT.stdout
 #else
 let systemStderr = Glibc.stderr!
 let systemStdout = Glibc.stdout!


### PR DESCRIPTION
Import `CRT` instead of `MSVCRT`.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
