### PR TITLE
Add sushichop/Puppy to list of backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [jagreenwood/swift-log-datadog](https://github.com/jagreenwood/swift-log-datadog)  | a logging backend which sends log messages to the [Datadog](https://www.datadoghq.com/log-management/) log management service |
 | [google/SwiftLogFireCloud](https://github.com/google/swiftlogfirecloud)  | a logging backend for time series logging which pushes logs as flat files to Firebase Cloud Storage. |
 | [crspybits/swift-log-file](https://github.com/crspybits/swift-log-file)  | a simple local file logger (using `Foundation` `FileManager`) |
+| [sushichop/Puppy](https://github.com/sushichop/Puppy) | a logging backend that supports multiple transports(console, file, syslog, etc.) and has the feature with formatting and file log rotation |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Updates the list of SwiftLog backend implementations to include [Puppy](https://github.com/sushichop/Puppy).

### Motivation:

**I think this PR helps people to be able to find the compatible backends more easily.**
_[Details]_
I built the library that supports multiple transports(console, file, syslog, etc.) as loggers. It not only works alone, but also as a backend for swift-log. 
Furthermore, it has file log rotation feature and you can also customize the log format as you like. And it supports both Linux and Darwin.

### Modifications:

Append `sushichop/Puppy` to the list of implementations in the README.

### Result:

This PR makes no changes to code, just the README.
