### PR TITLE
Added dependency update for Swift 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,16 @@ If you have a server-side Swift application, or maybe a cross-platform (for exam
 and to your application/library target, add `"Logging"` to your `dependencies`, e.g. like this:
 
 ```swift
+// Target syntax for Swift up to version 5.1
 .target(name: "BestExampleApp", dependencies: ["Logging"]),
+
+// Target for Swift 5.2
+.target(name: "BestExampleApp", dependencies: [
+    .product(name: "Logging", package: "swift-log")
+],
+
 ```
+
 
 #### Let's log
 


### PR DESCRIPTION
Starting in Swift 5.2 the target dependency format changes, this PR updates the README with the new format.

### Motivation:

When I added swift-log to my project it wouldn't work, after looking at the error I saw it was a straightforward update and wanted to help others with the same change,.

### Modifications:

README only, no code updates.

### Result:

Less confusion for Swift 5.2 users.
