### PR TITLE
Add support for logging in SwiftWasm (via `WASILibc`)

### DIFF
--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -30,7 +30,7 @@
 import Darwin
 #elseif os(Windows)
 import WinSDK
-#else
+#elseif canImport(Glibc)
 import Glibc
 #endif
 
@@ -44,6 +44,8 @@ internal final class Lock {
     #if os(Windows)
     fileprivate let mutex: UnsafeMutablePointer<SRWLOCK> =
         UnsafeMutablePointer.allocate(capacity: 1)
+    #elseif canImport(WASILibc)
+    fileprivate let mutex : Void
     #else
     fileprivate let mutex: UnsafeMutablePointer<pthread_mutex_t> =
         UnsafeMutablePointer.allocate(capacity: 1)
@@ -53,6 +55,8 @@ internal final class Lock {
     public init() {
         #if os(Windows)
         InitializeSRWLock(self.mutex)
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         var attr = pthread_mutexattr_t()
         pthread_mutexattr_init(&attr)
@@ -66,11 +70,14 @@ internal final class Lock {
     deinit {
         #if os(Windows)
         // SRWLOCK does not need to be free'd
+        self.mutex.deallocate()
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_mutex_destroy(self.mutex)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        #endif
         self.mutex.deallocate()
+        #endif
     }
 
     /// Acquire the lock.
@@ -80,6 +87,8 @@ internal final class Lock {
     public func lock() {
         #if os(Windows)
         AcquireSRWLockExclusive(self.mutex)
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_mutex_lock(self.mutex)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
@@ -93,6 +102,8 @@ internal final class Lock {
     public func unlock() {
         #if os(Windows)
         ReleaseSRWLockExclusive(self.mutex)
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_mutex_unlock(self.mutex)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
@@ -136,6 +147,9 @@ internal final class ReadWriteLock {
     fileprivate let rwlock: UnsafeMutablePointer<SRWLOCK> =
         UnsafeMutablePointer.allocate(capacity: 1)
     fileprivate var shared: Bool = true
+    #elseif canImport(WASILibc)
+    // no threading on WASI yet
+    fileprivate let rwlock: Void
     #else
     fileprivate let rwlock: UnsafeMutablePointer<pthread_rwlock_t> =
         UnsafeMutablePointer.allocate(capacity: 1)
@@ -145,6 +159,8 @@ internal final class ReadWriteLock {
     public init() {
         #if os(Windows)
         InitializeSRWLock(self.rwlock)
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_rwlock_init(self.rwlock, nil)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
@@ -154,11 +170,14 @@ internal final class ReadWriteLock {
     deinit {
         #if os(Windows)
         // SRWLOCK does not need to be free'd
+        self.rwlock.deallocate()
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_rwlock_destroy(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
-        #endif
         self.rwlock.deallocate()
+        #endif
     }
 
     /// Acquire a reader lock.
@@ -169,6 +188,8 @@ internal final class ReadWriteLock {
         #if os(Windows)
         AcquireSRWLockShared(self.rwlock)
         self.shared = true
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_rwlock_rdlock(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
@@ -183,6 +204,8 @@ internal final class ReadWriteLock {
         #if os(Windows)
         AcquireSRWLockExclusive(self.rwlock)
         self.shared = false
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_rwlock_wrlock(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
@@ -201,6 +224,8 @@ internal final class ReadWriteLock {
         } else {
             ReleaseSRWLockExclusive(self.rwlock)
         }
+        #elseif canImport(WASILibc)
+        // no threading on WASI yet
         #else
         let err = pthread_rwlock_unlock(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -72,12 +72,11 @@ internal final class Lock {
     deinit {
         #if os(Windows)
         // SRWLOCK does not need to be free'd
-        self.mutex.deallocate()
         #else
         let err = pthread_mutex_destroy(self.mutex)
         precondition(err == 0, "\(#function) failed in pthread_mutex with error \(err)")
-        self.mutex.deallocate()
         #endif
+        self.mutex.deallocate()
     }
 
     /// Acquire the lock.
@@ -161,12 +160,11 @@ internal final class ReadWriteLock {
     deinit {
         #if os(Windows)
         // SRWLOCK does not need to be free'd
-        self.rwlock.deallocate()
         #else
         let err = pthread_rwlock_destroy(self.rwlock)
         precondition(err == 0, "\(#function) failed in pthread_rwlock with error \(err)")
-        self.rwlock.deallocate()
         #endif
+        self.rwlock.deallocate()
     }
 
     /// Acquire a reader lock.

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -19,6 +19,11 @@ import CRT
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WASILibc)
+// WASILibc doesn't have stdio, e.g. things like `FILE` yet
+// WASILibc doesn't have `strftime`, but Foundation `DateFormatter`
+import struct Foundation.Date
+import class  Foundation.DateFormatter
+let sharedDateFormatter = DateFormatter()
 #else
 #error("Unsupported runtime")
 #endif
@@ -750,6 +755,10 @@ public struct StreamLogHandler: LogHandler {
     }
 
     private func timestamp() -> String {
+        #if canImport(WASILibc)
+        // WASI doesn't have `strftime`, but Foundation `DateFormatter`
+        return sharedDateFormatter.string(from: Date())
+        #else
         var buffer = [Int8](repeating: 0, count: 255)
         var timestamp = time(nil)
         let localTime = localtime(&timestamp)
@@ -759,6 +768,7 @@ public struct StreamLogHandler: LogHandler {
                 String(cString: $0.baseAddress!)
             }
         }
+        #endif
     }
 }
 

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -19,7 +19,6 @@ import CRT
 #elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WASILibc)
-import struct WASILibc.FILE
 #else
 #error("Unsupported runtime")
 #endif
@@ -607,6 +606,15 @@ public struct MultiplexLogHandler: LogHandler {
     }
 }
 
+#if canImport(WASILibc)
+// There is no stdio/FILE in WASI yet, neither stdout/err. But it does
+// support `print`.
+internal struct PrintOutputStream: TextOutputStream {
+    internal func write(_ string: String) {
+        print(string)
+    }
+}
+#else
 /// A wrapper to facilitate `print`-ing to stderr and stdio that
 /// ensures access to the underlying `FILE` is locked to prevent
 /// cross-thread interleaving of output.
@@ -654,6 +662,7 @@ internal struct StdioOutputStream: TextOutputStream {
         case always
     }
 }
+#endif
 
 // Prevent name clashes
 #if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
@@ -666,8 +675,7 @@ let systemStdout = CRT.stdout
 let systemStderr = Glibc.stderr!
 let systemStdout = Glibc.stdout!
 #elseif canImport(WASILibc)
-let systemStderr = WASILibc.stderr!
-let systemStdout = WASILibc.stdout!
+// no stdio on WASI yet
 #else
 #error("Unsupported runtime")
 #endif
@@ -677,12 +685,20 @@ let systemStdout = WASILibc.stdout!
 public struct StreamLogHandler: LogHandler {
     /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
     public static func standardOutput(label: String) -> StreamLogHandler {
-        return StreamLogHandler(label: label, stream: StdioOutputStream.stdout)
+        #if canImport(WASILibc)
+            return StreamLogHandler(label: label, stream: PrintOutputStream())
+        #else
+            return StreamLogHandler(label: label, stream: StdioOutputStream.stdout)
+        #endif
     }
 
     /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
     public static func standardError(label: String) -> StreamLogHandler {
-        return StreamLogHandler(label: label, stream: StdioOutputStream.stderr)
+        #if canImport(WASILibc)
+            return standardOutput(label: label)
+        #else
+            return StreamLogHandler(label: label, stream: StdioOutputStream.stderr)
+        #endif
     }
 
     private let stream: TextOutputStream

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -20,10 +20,9 @@ import CRT
 import Glibc
 #elseif canImport(WASILibc)
 // WASILibc doesn't have stdio, e.g. things like `FILE` yet
-// WASILibc doesn't have `strftime`, but Foundation `DateFormatter`
-import struct Foundation.Date
-import class  Foundation.DateFormatter
-let sharedDateFormatter = DateFormatter()
+import func WASILibc.strftime
+import func WASILibc.time
+import func WASILibc.localtime
 #else
 #error("Unsupported runtime")
 #endif
@@ -773,10 +772,6 @@ public struct StreamLogHandler: LogHandler {
     }
 
     private func timestamp() -> String {
-        #if canImport(WASILibc)
-        // WASI doesn't have `strftime`, but Foundation `DateFormatter`
-        return sharedDateFormatter.string(from: Date())
-        #else
         var buffer = [Int8](repeating: 0, count: 255)
         var timestamp = time(nil)
         let localTime = localtime(&timestamp)
@@ -786,7 +781,6 @@ public struct StreamLogHandler: LogHandler {
                 String(cString: $0.baseAddress!)
             }
         }
-        #endif
     }
 }
 


### PR DESCRIPTION
This is a port of Logging to the SwiftWasm `WASILibc`.

### Motivation:

I'd like to log things in Wasm as well.

### Modifications:

1. The library was using a lot of `import Glibc` as a fallback (you might want to consider to move to `canImport`). Added additional checks for `WASILibc` and emit an `#error` when no known runtime is available.
2. `WASILibc` (well, WASI) doesn't support threading and hence locks. `#if` guarded the Locks.swift file to not build the Lock classes w/ WASILibc. Then adjust the few invocations on the callsites to not use locks on WASILibc.
3. `WASILibc` doesn't have stdio, but it does have Foundation `print`. Defines a `TextOutputStream` using that when on WASILibc, and do not use the Stdio variant. (implies using the same stream for both stdout/err)
4. `WASILibc` doesn't have `strftime`, but it does have a working Foundation `DateFormatter`/`Date`. Use that instead of timestamp formatting.

### Result:

swift-log can be used in Wasm environments.

Source:
```swift
import Logging
let logger = Logger(label: "zz.log")
logger.info("Hello World!")
```

```sh
helge@M1ni cowsa $ swift build --triple wasm32-unknown-wasi
[3/3] Linking cowsa.wasm
helge@M1ni cowsa $ wasmer .build/debug/cowsa.wasm 
2021-01-11 17:44:06.926 info zz.log : Hello World!
```
