### PR TITLE
Suggest more robust commit template

### DIFF
--- a/dev/git.commit.template
+++ b/dev/git.commit.template
@@ -1,4 +1,4 @@
-One line description of your change
+One line description of your change (72 characters) : Github truncates any subject line greater than that.
 
 Motivation:
 
@@ -12,3 +12,10 @@ Describe the modifications you've done.
 Result:
 
 After your change, what will change.
+
+
+Resolves:
+#tracking_no
+
+Referendes:
+See also: #456, #789


### PR DESCRIPTION
This template focusses on adding more information at the same time limiting the subject because github truncates subject greater than 72 with (...)
This can be useful when using git log,shortlog commands.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
