### PR TITLE
Use fwrite instead of puts in the Stdio logging

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -825,7 +825,7 @@ internal struct StdioOutputStream: TextOutputStream {
                 funlockfile(self.file)
                 #endif
             }
-            _ = fputs(ptr, self.file)
+            _ = fwrite(ptr, 1, strlen(ptr), self.file)
             if case .always = self.flushMode {
                 self.flush()
             }


### PR DESCRIPTION
Change fputs to fwrite

 ### Motivation:

https://github.com/apple/swift-log/issues/180

Printing  a 0 byte could be a hard to debug if we lose everything after the 0 byte with fputs or if we accidentally pass a string that's not properly null-terminated, thus using fwrite, it solve that problem.

### Modifications:

replaced fputs with fwrite