### PR TITLE
Fix function being dropped on source-less trace

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -176,7 +176,7 @@ extension Logger {
     public func trace(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
-        self.trace(message(), metadata: metadata(), source: nil, file: file, line: line)
+        self.trace(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
 
     /// Log a message passing with the `Logger.Level.debug` log level.


### PR DESCRIPTION
### Motivation:

When using the recently re-introduced source-less version of trace, the function parameter that reaches the underlying LogHandler is wrong.

### Modifications:

Pass the function parameter to trace with source parameter.

### Result:

* With these changes, the function parameter that reaches the underlying LogHandler has the correct value.
* Fixes #184