### PR TITLE
use #fileID for Swift 5.3+

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -49,6 +49,7 @@ public struct Logger {
 }
 
 extension Logger {
+    #if compiler(>=5.3)
     /// Log a message passing the log level as a parameter.
     ///
     /// If the `logLevel` passed to this method is more severe than the `Logger`'s `logLevel`, it will be logged,
@@ -58,14 +59,32 @@ extension Logger {
     ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    source: @autoclosure () -> String? = nil,
+                    file: String = #fileID, function: String = #function, line: UInt = #line) {
+        if self.logLevel <= level {
+            self.handler.log(level: level,
+                             message: message(),
+                             metadata: metadata(),
+                             source: source() ?? Logger.currentModule(fileID: (file)),
+                             file: file, function: function, line: line)
+        }
+    }
+
+    #else
     @inlinable
     public func log(level: Logger.Level,
                     _ message: @autoclosure () -> Logger.Message,
@@ -80,6 +99,7 @@ extension Logger {
                              file: file, function: function, line: line)
         }
     }
+    #endif
 
     /// Log a message passing the log level as a parameter.
     ///
@@ -91,11 +111,21 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func log(level: Logger.Level,
+                    _ message: @autoclosure () -> Logger.Message,
+                    metadata: @autoclosure () -> Logger.Metadata? = nil,
+                    file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: level, message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func log(level: Logger.Level,
                     _ message: @autoclosure () -> Logger.Message,
@@ -103,6 +133,7 @@ extension Logger {
                     file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: level, message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Add, change, or remove a logging metadata item.
     ///
@@ -144,14 +175,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .trace, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func trace(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -159,6 +202,7 @@ extension Logger {
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .trace, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// If `.trace` is at least as severe as the `Logger`'s `logLevel`, it will be logged,
     /// otherwise nothing will happen.
@@ -167,17 +211,27 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func trace(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.trace(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func trace(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.trace(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.debug` log level.
     ///
@@ -187,21 +241,33 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
     @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .debug, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     public func debug(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       source: @autoclosure () -> String? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .debug, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.debug` log level.
     ///
@@ -212,17 +278,27 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func debug(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.debug(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func debug(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.debug(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.info` log level.
     ///
@@ -232,14 +308,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     source: @autoclosure () -> String? = nil,
+                     file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .info, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func info(_ message: @autoclosure () -> Logger.Message,
                      metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -247,6 +335,7 @@ extension Logger {
                      file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .info, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.info` log level.
     ///
@@ -257,17 +346,27 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func info(_ message: @autoclosure () -> Logger.Message,
+                     metadata: @autoclosure () -> Logger.Metadata? = nil,
+                     file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.info(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func info(_ message: @autoclosure () -> Logger.Message,
                      metadata: @autoclosure () -> Logger.Metadata? = nil,
                      file: String = #file, function: String = #function, line: UInt = #line) {
         self.info(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.notice` log level.
     ///
@@ -277,14 +376,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       source: @autoclosure () -> String? = nil,
+                       file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .notice, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func notice(_ message: @autoclosure () -> Logger.Message,
                        metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -292,6 +403,7 @@ extension Logger {
                        file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .notice, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.notice` log level.
     ///
@@ -301,20 +413,31 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
     @inlinable
+    public func notice(_ message: @autoclosure () -> Logger.Message,
+                       metadata: @autoclosure () -> Logger.Metadata? = nil,
+                       file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.notice(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     public func notice(_ message: @autoclosure () -> Logger.Message,
                        metadata: @autoclosure () -> Logger.Metadata? = nil,
                        file: String = #file, function: String = #function, line: UInt = #line) {
         self.notice(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.warning` log level.
     ///
@@ -324,14 +447,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        source: @autoclosure () -> String? = nil,
+                        file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .warning, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func warning(_ message: @autoclosure () -> Logger.Message,
                         metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -339,6 +474,7 @@ extension Logger {
                         file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .warning, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.warning` log level.
     ///
@@ -349,17 +485,27 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func warning(_ message: @autoclosure () -> Logger.Message,
+                        metadata: @autoclosure () -> Logger.Metadata? = nil,
+                        file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.warning(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func warning(_ message: @autoclosure () -> Logger.Message,
                         metadata: @autoclosure () -> Logger.Metadata? = nil,
                         file: String = #file, function: String = #function, line: UInt = #line) {
         self.warning(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.error` log level.
     ///
@@ -369,14 +515,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      source: @autoclosure () -> String? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .error, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func error(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -384,6 +542,7 @@ extension Logger {
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .error, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.error` log level.
     ///
@@ -394,17 +553,27 @@ extension Logger {
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func error(_ message: @autoclosure () -> Logger.Message,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.error(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func error(_ message: @autoclosure () -> Logger.Message,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.error(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.critical` log level.
     ///
@@ -413,14 +582,26 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         source: @autoclosure () -> String? = nil,
+                         file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.log(level: .critical, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func critical(_ message: @autoclosure () -> Logger.Message,
                          metadata: @autoclosure () -> Logger.Metadata? = nil,
@@ -428,6 +609,7 @@ extension Logger {
                          file: String = #file, function: String = #function, line: UInt = #line) {
         self.log(level: .critical, message(), metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
+    #endif
 
     /// Log a message passing with the `Logger.Level.critical` log level.
     ///
@@ -436,20 +618,32 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates to. Currently, it defaults to the folder containing the
-    ///              file that is emitting the log message, which usually is the module.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message (on Swift 5.3 or
+    ///              newer and the folder name containing the log emitting file on Swift 5.2 or
+    ///              older).
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
-    ///            defaults to `#file`).
+    ///            defaults to `#fileID` (on Swift 5.3 or newer and `#file` on Swift 5.2 or older).
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
     ///                it defaults to `#function`).
     ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#line`).
+    #if compiler(>=5.3)
+    @inlinable
+    public func critical(_ message: @autoclosure () -> Logger.Message,
+                         metadata: @autoclosure () -> Logger.Metadata? = nil,
+                         file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.critical(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+    }
+
+    #else
     @inlinable
     public func critical(_ message: @autoclosure () -> Logger.Message,
                          metadata: @autoclosure () -> Logger.Metadata? = nil,
                          file: String = #file, function: String = #function, line: UInt = #line) {
         self.critical(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    #endif
 }
 
 /// The `LoggingSystem` is a global facility where the default logging backend implementation (`LogHandler`) can be
@@ -979,6 +1173,18 @@ extension Logger {
             String($0)
         } ?? "n/a"
     }
+
+    #if compiler(>=5.3)
+    @inlinable
+    internal static func currentModule(fileID: String = #fileID) -> String {
+        let utf8All = fileID.utf8
+        if let slashIndex = utf8All.firstIndex(of: UInt8(ascii: "/")) {
+            return String(fileID[..<slashIndex])
+        } else {
+            return "n/a"
+        }
+    }
+    #endif
 }
 
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -41,6 +41,7 @@ extension LoggingTest {
             ("testAllLogLevelsWork", testAllLogLevelsWork),
             ("testAllLogLevelByFunctionRefWithSource", testAllLogLevelByFunctionRefWithSource),
             ("testAllLogLevelByFunctionRefWithoutSource", testAllLogLevelByFunctionRefWithoutSource),
+            ("testLogsEmittedFromSubdirectoryGetCorrectModuleInNewerSwifts", testLogsEmittedFromSubdirectoryGetCorrectModuleInNewerSwifts),
             ("testLogMessageWithStringInterpolation", testLogMessageWithStringInterpolation),
             ("testLoggingAString", testLoggingAString),
             ("testMultiplexerIsValue", testMultiplexerIsValue),

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -301,7 +301,7 @@ class LoggingTest: XCTestCase {
     }
 
     private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> Logger.Message {
-        XCTFail("should not have been evaluated", file: (file), line: line)
+        XCTFail("should not have been evaluated", file: file, line: line)
         return "should not have been evaluated"
     }
 
@@ -455,6 +455,15 @@ class LoggingTest: XCTestCase {
         let error = logger.error(_:metadata:file:function:line:)
         let critical = logger.critical(_:metadata:file:function:line:)
 
+        #if compiler(>=5.3)
+        trace("yes: trace", [:], #fileID, #function, #line)
+        debug("yes: debug", [:], #fileID, #function, #line)
+        info("yes: info", [:], #fileID, #function, #line)
+        notice("yes: notice", [:], #fileID, #function, #line)
+        warning("yes: warning", [:], #fileID, #function, #line)
+        error("yes: error", [:], #fileID, #function, #line)
+        critical("yes: critical", [:], #fileID, #function, #line)
+        #else
         trace("yes: trace", [:], #file, #function, #line)
         debug("yes: debug", [:], #file, #function, #line)
         info("yes: info", [:], #file, #function, #line)
@@ -462,6 +471,7 @@ class LoggingTest: XCTestCase {
         warning("yes: warning", [:], #file, #function, #line)
         error("yes: error", [:], #file, #function, #line)
         critical("yes: critical", [:], #file, #function, #line)
+        #endif
 
         testLogging.history.assertExist(level: .trace, message: "yes: trace")
         testLogging.history.assertExist(level: .debug, message: "yes: debug")
@@ -470,6 +480,30 @@ class LoggingTest: XCTestCase {
         testLogging.history.assertExist(level: .warning, message: "yes: warning")
         testLogging.history.assertExist(level: .error, message: "yes: error")
         testLogging.history.assertExist(level: .critical, message: "yes: critical")
+    }
+
+    func testLogsEmittedFromSubdirectoryGetCorrectModuleInNewerSwifts() {
+        let testLogging = TestLogging()
+        LoggingSystem.bootstrapInternal(testLogging.make)
+
+        var logger = Logger(label: "\(#function)")
+        logger.logLevel = .trace
+
+        emitLogMessage("hello", to: logger)
+
+        #if compiler(>=5.3)
+        let moduleName = "LoggingTests" // the actual name
+        #else
+        let moduleName = "SubDirectoryOfLoggingTests" // the last path component of `#file` showing the failure mode
+        #endif
+
+        testLogging.history.assertExist(level: .trace, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .debug, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .info, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .notice, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .warning, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .error, message: "hello", source: moduleName)
+        testLogging.history.assertExist(level: .critical, message: "hello", source: moduleName)
     }
 
     func testLogMessageWithStringInterpolation() {
@@ -806,9 +840,18 @@ class LoggingTest: XCTestCase {
 }
 
 extension Logger {
+    #if compiler(>=5.3)
+    public func error(error: Error,
+                      metadata: @autoclosure () -> Logger.Metadata? = nil,
+                      file: String = #fileID, function: String = #function, line: UInt = #line) {
+        self.error("\(error.localizedDescription)", metadata: metadata(), file: file, function: function, line: line)
+    }
+
+    #else
     public func error(error: Error,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #file, function: String = #function, line: UInt = #line) {
         self.error("\(error.localizedDescription)", metadata: metadata(), file: file, function: function, line: line)
     }
+    #endif
 }

--- a/Tests/LoggingTests/SubDirectoryOfLoggingTests/EmitALogFromSubDirectory.swift
+++ b/Tests/LoggingTests/SubDirectoryOfLoggingTests/EmitALogFromSubDirectory.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+
+internal func emitLogMessage(_ message: Logger.Message, to logger: Logger) {
+    logger.trace(message)
+    logger.debug(message)
+    logger.info(message)
+    logger.notice(message)
+    logger.warning(message)
+    logger.error(message)
+    logger.critical(message)
+}

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -174,6 +174,34 @@ internal struct LogEntry {
 }
 
 extension History {
+    #if compiler(>=5.3)
+    func assertExist(level: Logger.Level,
+                     message: String,
+                     metadata: Logger.Metadata? = nil,
+                     source: String? = nil,
+                     file: StaticString = #file,
+                     fileID: String = #fileID,
+                     line: UInt = #line) {
+        let source = source ?? Logger.currentModule(fileID: "\(fileID)")
+        let entry = self.find(level: level, message: message, metadata: metadata, source: source)
+        XCTAssertNotNil(entry, "entry not found: \(level), \(source), \(String(describing: metadata)), \(message)",
+                        file: file, line: line)
+    }
+
+    func assertNotExist(level: Logger.Level,
+                        message: String,
+                        metadata: Logger.Metadata? = nil,
+                        source: String? = nil,
+                        file: StaticString = #file,
+                        fileID: String = #file,
+                        line: UInt = #line) {
+        let source = source ?? Logger.currentModule(fileID: "\(fileID)")
+        let entry = self.find(level: level, message: message, metadata: metadata, source: source)
+        XCTAssertNil(entry, "entry was found: \(level), \(source), \(String(describing: metadata)), \(message)",
+                     file: file, line: line)
+    }
+
+    #else
     func assertExist(level: Logger.Level,
                      message: String,
                      metadata: Logger.Metadata? = nil,
@@ -183,7 +211,7 @@ extension History {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNotNil(entry, "entry not found: \(level), \(source), \(String(describing: metadata)), \(message)",
-                        file: (file), line: line)
+                        file: file, line: line)
     }
 
     func assertNotExist(level: Logger.Level,
@@ -195,8 +223,9 @@ extension History {
         let source = source ?? Logger.currentModule(filePath: "\(file)")
         let entry = self.find(level: level, message: message, metadata: metadata, source: source)
         XCTAssertNil(entry, "entry was found: \(level), \(source), \(String(describing: metadata)), \(message)",
-                     file: (file), line: line)
+                     file: file, line: line)
     }
+    #endif
 
     func find(level: Logger.Level, message: String, metadata: Logger.Metadata? = nil, source: String) -> LogEntry? {
         return self.entries.first { entry in


### PR DESCRIPTION
Motivation:

Right now, we use the full path (`#file`) for the logging as well as for
parsing out the module name (which goes into `source` by default).

This has two problems:

1. The file names contain the build server's full path, ie. aren't
   portable across different compiles (and are very long).
2. The module name parsing fails if we log from a file that's not in a
   directory named just like the module.

Modification:

Switch `#file` for `#fileID`. This changes a bunch of things:

- `source` is always the module name by default (great!)
- `file` changes from `/the/full/path/on/disk` to `ModuleName/FileBaseName.swift` (I think better, but it's a change)

Result:

`source` is more correct, `file` will be different.