### PR TITLE
Improve StdioOutputStream with fwrite (#180)

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -808,7 +808,7 @@ internal struct StdioOutputStream: TextOutputStream {
     internal let flushMode: FlushMode
 
     internal func write(_ string: String) {
-        contiguousUTF8(string).withContiguousStorageIfAvailable { utf8Bytes in
+        self.contiguousUTF8(string).withContiguousStorageIfAvailable { utf8Bytes in
             #if os(Windows)
             _lock_file(self.file)
             #elseif canImport(WASILibc)

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -51,6 +51,7 @@ extension LoggingTest {
             ("testStreamLogHandlerOutputFormat", testStreamLogHandlerOutputFormat),
             ("testStreamLogHandlerOutputFormatWithMetaData", testStreamLogHandlerOutputFormatWithMetaData),
             ("testStreamLogHandlerOutputFormatWithOrderedMetadata", testStreamLogHandlerOutputFormatWithOrderedMetadata),
+            ("testStdioOutputStreamWrite", testStdioOutputStreamWrite),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
             ("testOverloadingError", testOverloadingError),
         ]

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -736,7 +736,6 @@ class LoggingTest: XCTestCase {
             let output = String(decoding: UnsafeRawBufferPointer(start: UnsafeRawPointer(readBuffer), count: size), as: UTF8.self)
             let messageSucceeded = output.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(testString)
             XCTAssertTrue(messageSucceeded)
-
         }
     }
 

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -723,6 +723,23 @@ class LoggingTest: XCTestCase {
         XCTAssert(interceptStream.strings[1].contains("a=a1 b=b1"))
     }
 
+    func testStdioOutputStreamWrite() {
+        self.withWriteReadFDsAndReadBuffer { writeFD, readFD, readBuffer in
+            let logStream = StdioOutputStream(file: writeFD, flushMode: .always)
+            LoggingSystem.bootstrapInternal { StreamLogHandler(label: $0, stream: logStream) }
+            let log = Logger(label: "test")
+            let testString = "hello\u{0} world"
+            log.critical("\(testString)")
+
+            let size = read(readFD, readBuffer, 256)
+
+            let output = String(decoding: UnsafeRawBufferPointer(start: UnsafeRawPointer(readBuffer), count: size), as: UTF8.self)
+            let messageSucceeded = output.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(testString)
+            XCTAssertTrue(messageSucceeded)
+
+        }
+    }
+
     func testStdioOutputStreamFlush() {
         // flush on every statement
         self.withWriteReadFDsAndReadBuffer { writeFD, readFD, readBuffer in
@@ -756,7 +773,7 @@ class LoggingTest: XCTestCase {
         var fds: [Int32] = [-1, -1]
         fds.withUnsafeMutableBufferPointer { ptr in
             let err = pipe(ptr.baseAddress!)
-            XCTAssertEqual(err, 0, "pipe faild \(err)")
+            XCTAssertEqual(err, 0, "pipe failed \(err)")
         }
 
         let writeFD = fdopen(fds[1], "w")
@@ -767,11 +784,11 @@ class LoggingTest: XCTestCase {
         }
 
         var err = setvbuf(writeFD, writeBuffer, _IOFBF, 256)
-        XCTAssertEqual(err, 0, "setvbuf faild \(err)")
+        XCTAssertEqual(err, 0, "setvbuf failed \(err)")
 
         let readFD = fds[0]
         err = fcntl(readFD, F_SETFL, fcntl(readFD, F_GETFL) | O_NONBLOCK)
-        XCTAssertEqual(err, 0, "fcntl faild \(err)")
+        XCTAssertEqual(err, 0, "fcntl failed \(err)")
 
         let readBuffer = UnsafeMutablePointer<Int8>.allocate(capacity: 256)
         defer {


### PR DESCRIPTION
# Replaced `fputs` with `fwrite`, added test and made spelling corrections

### _WIP help_
_(for reference, see the code changes)_
On the testing side, I'm currently using `String(validatingUTF8: <unsafe-mutable-pointer>` to turn a UnsafeMutablePointer<Int8> into a String. However, this seems to return a string that stops at the first 0 byte E.g. for a "hello\u{0} world" log it outputs hello only. NB. I have checked that `fwrite` correctly logs a message longer than "hello" through count but testing this is hard. @weissi @ktoso Have you got any suggestions?

### Motivation:

_If a 0 byte is logged, `fputs` would not output the content after the 0 byte making it harder to debug (see #180). `fwrite` uses a count argument so content after 0 byte can be logged._

### Modifications:

_Replaced `fputs` with the correct call to `fwrite`.   Added helper internal func `contiguousUTF8(_ string: String) -> String.UTF8View`. Added `testStdioOutputStreamWrite()` to test ability to log content after 0 byte._

### Result:

_Improved debugging experience_
