### PR TITLE
Include source in StreamLogHandler output

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -917,7 +917,7 @@ public struct StreamLogHandler: LogHandler {
             : self.prettify(self.metadata.merging(metadata!, uniquingKeysWith: { _, new in new }))
 
         var stream = self.stream
-        stream.write("\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") \(message)\n")
+        stream.write("\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\n")
     }
 
     private func prettify(_ metadata: Logger.Metadata) -> String? {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -669,12 +669,13 @@ class LoggingTest: XCTestCase {
         LoggingSystem.bootstrapInternal { _ in
             StreamLogHandler(label: label, stream: interceptStream)
         }
+        let source = "testSource"
         let log = Logger(label: label)
 
         let testString = "my message is better than yours"
-        log.critical("\(testString)")
+        log.critical("\(testString)", source: source)
 
-        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\(testString)$"
+        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\\[\(source)\\]\\s\(testString)$"
 
         let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
 
@@ -688,12 +689,13 @@ class LoggingTest: XCTestCase {
         LoggingSystem.bootstrapInternal { _ in
             StreamLogHandler(label: label, stream: interceptStream)
         }
+        let source = "testSource"
         let log = Logger(label: label)
 
         let testString = "my message is better than yours"
-        log.critical("\(testString)", metadata: ["test": "test"])
+        log.critical("\(testString)", metadata: ["test": "test"], source: source)
 
-        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\(testString)$"
+        let pattern = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\\[\(source)\\]\\s\(testString)$"
 
         let messageSucceeded = interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(of: pattern, options: .regularExpression) != nil
 


### PR DESCRIPTION
Include source in StreamLogHandler output.

### Motivation:

When using the same Logger across an application in combination with the default StreamLogHandler, it may be difficult to differentiate between logs produced by different modules. ServiceLifecycle works around this by prepending the log message with [Lifecycle], which is what I'd like to do StreamLogHandler by default, leveraging the source log parameter.

### Modifications:

StreamLogHandler will include the source in brackets right before the log message when writing a log.

### Result:

Logs from different modules are easily differentiable when produced using the same Logger instance.