### PR TITLE
Add `SwiftLogNoOpLogHandler.init(_: String)`

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1147,6 +1147,8 @@ public struct StreamLogHandler: LogHandler {
 public struct SwiftLogNoOpLogHandler: LogHandler {
     public init() {}
 
+    public init(_: String) {}
+
     @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
 
     @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {


### PR DESCRIPTION
Motivation:

`LogHandler` facotories are given a label as input and return a
`LogHandler`. Since the no-op handler doesn't care about the label
callers must provide a thunk: `{ _ in SwiftLogNoOpLogHandler() }`.
That's fine but slightly more annoying to type than it needs to be.

Modifications:

- Add `SwiftLogNoOpLogHandler.init(_: String)`

Result:

Users can create a logger with the no-op handler with:

```swift
Logger(label: "foo", factory: SwiftLogNoOpLogHandler.init)
```

instead of:

```swift
Logger(label: "foo", factory: { _ in SwiftLogNoOpLogHandler() })
```