### PR TITLE
update 5.4 to release docker image

### DIFF
--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -6,7 +6,8 @@ services:
     image: swift-log:20.04-5.4
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.4-focal"
+        ubuntu_version: "focal"
+        swift_version: "5.4"
 
   test:
     image: swift-log:20.04-5.4


### PR DESCRIPTION
motivation: 5.4 is out!

changes: use release docker images instead of nightly
