### PR TITLE
Logging: avoid a deprecation warning on Windows

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1132,9 +1132,19 @@ public struct StreamLogHandler: LogHandler {
 
     private func timestamp() -> String {
         var buffer = [Int8](repeating: 0, count: 255)
+        #if os(Windows)
+        var timestamp: __time64_t = __time64_t()
+        _ = _time64(&timestamp)
+
+        var localTime: tm = tm()
+        _ = _localtime64_s(&localTime, &timestamp)
+
+        _ = strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", &localTime)
+        #else
         var timestamp = time(nil)
         let localTime = localtime(&timestamp)
         strftime(&buffer, buffer.count, "%Y-%m-%dT%H:%M:%S%z", localTime)
+        #endif
         return buffer.withUnsafeBufferPointer {
             $0.withMemoryRebound(to: CChar.self) {
                 String(cString: $0.baseAddress!)


### PR DESCRIPTION
Windows recommends the safety extension usage which in this case
explicitly allow you to be informed of failures.  This just avoids an
annoying warning when using logging in projects.

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_
