### PR TITLE
Add swift-log-elk as a new logging backend to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [crspybits/swift-log-file](https://github.com/crspybits/swift-log-file)  | a simple local file logger (using `Foundation` `FileManager`) |
 | [sushichop/Puppy](https://github.com/sushichop/Puppy) | a logging backend that supports multiple transports(console, file, syslog, etc.) and has the feature with formatting and file log rotation |
 | [luoxiu/LogDog](https://github.com/luoxiu/LogDog) | user-friendly logging with sinks and appenders |
+| [Apodini/swift-log-elk](https://github.com/Apodini/swift-log-elk) | a logging backend that formats, caches and sends log data to [elastic/logstash](https://github.com/elastic/logstash) |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
[swift-log-elk](https://github.com/Apodini/swift-log-elk) is a logging backend for [swift-log](https://github.com/apple/swift-log) that formats, caches and sends log data to [elastic/logstash](https://github.com/elastic/logstash) (most likely in combination with the ELK stack).

For further information, please take a look at the [repository](https://github.com/Apodini/swift-log-elk) itself :)