### PR TITLE
Change StreamLogHandler init to public

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1103,8 +1103,7 @@ public struct StreamLogHandler: LogHandler {
         }
     }
 
-    // internal for testing only
-    internal init(label: String, stream: TextOutputStream) {
+    public init(label: String, stream: TextOutputStream) {
         self.label = label
         self.stream = stream
     }


### PR DESCRIPTION
Change StreamLogHandler init to public

### Motivation:

If we just want to use TextOutputStream same as default StreamLogHandler, we can use the init to init ourself StreamLogHandler, eg, with FileHandle.

### Modifications:

Change to StreamLogHandler init from internal to public

### Result:

We can now use StreamLogHandler more fluently.