### PR TITLE
Add swift-log-SwiftyBeaver as a new logging backend to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [crspybits/swift-log-file](https://github.com/crspybits/swift-log-file)  | a simple local file logger (using `Foundation` `FileManager`) |
 | [sushichop/Puppy](https://github.com/sushichop/Puppy) | a logging backend that supports multiple transports(console, file, syslog, etc.) and has the feature with formatting and file log rotation |
 | [luoxiu/LogDog](https://github.com/luoxiu/LogDog) | user-friendly logging with sinks and appenders |
+| [ShivaHuang/swift-log-SwiftyBeaver](https://github.com/ShivaHuang/swift-log-SwiftyBeaver) | a logging backend for printing colored logging to Xcode console / file, or sending encrypted logging to [SwiftyBeaver](https://swiftybeaver.com) platform. |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Add [swift-log-SwiftyBeaver](https://github.com/ShivaHuang/swift-log-SwiftyBeaver) as a new logging backend to README.md.