### PR TITLE
[WIP] Metadata providers

### DIFF
--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -55,6 +55,9 @@ extension LoggingTest {
             ("testStdioOutputStreamWrite", testStdioOutputStreamWrite),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
             ("testOverloadingError", testOverloadingError),
+            ("testMetadataProvider", testMetadataProvider),
+            ("testMetadataProviderLocalProviderOverwrite", testMetadataProviderLocalProviderOverwrite),
+            ("testMetadataProviderLocalMetadataOverwrite", testMetadataProviderLocalMetadataOverwrite),
         ]
     }
 }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -42,7 +42,7 @@ internal struct TestLogHandler: LogHandler {
         self.label = label
         self.config = config
         self.recorder = recorder
-        self.logger = Logger(label: "test", StreamLogHandler.standardOutput(label: label))
+        self.logger = Logger(label: "test", StreamLogHandler.standardOutput(label: label), metadataProvider: { nil })
         self.logger.logLevel = .debug
     }
 


### PR DESCRIPTION
Add `MetadataProvider` closure to be run on each log statement to attach the current value of something (e.g. a task-local) to the statement's metadata values (#205).

### Motivation:

Closes #205

### Modifications:

- `LoggingSystem` gains a new `provideMetadata` method
- `LoggingSystem` stores an array of `MetadataProvider`s
- `Logger` gains a new initializer taking an overwriting `MetadataProvider`
- `Logger` executes the `MetadataProvider` before logging a statement, attaching the resulting values to the statement's metadata

### Result:

It becomes easier to attach metadata to each log statement where the value can be derived without a method argument such as retrieving from the current task local storage. Instead of writing the code to retrieve such values per log statement it can instead be set up once.