### PR TITLE
Enforce Sendable conformance for LogHandlers Swift-Log, and make Logger Sendable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Logging API open source project
@@ -17,6 +17,10 @@ import PackageDescription
 
 let package = Package(
     name: "swift-log",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+    ],
     products: [
         .library(name: "Logging", targets: ["Logging"]),
     ],

--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -113,7 +113,7 @@
 /// Please note that the above `LogHandler` will still pass the 'log level is a value' test above it iff the global log
 /// level has not been overridden. And most importantly it passes the requirement listed above: A change to the log
 /// level on one `Logger` should not affect the log level of another `Logger` variable.
-public protocol LogHandler {
+public protocol LogHandler: Sendable {
     /// This method is called when a `LogHandler` must emit a log message. There is no need for the `LogHandler` to
     /// check if the `level` is above or below the configured `logLevel` as `Logger` already performed this check and
     /// determined that a message should be logged.
@@ -126,7 +126,7 @@ public protocol LogHandler {
     ///     - file: The file the log message was emitted from.
     ///     - function: The function the log line was emitted from.
     ///     - line: The line the log message was emitted from.
-    func log(level: Logger.Level,
+    @Sendable func log(level: Logger.Level,
              message: Logger.Message,
              metadata: Logger.Metadata?,
              source: String,

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -30,7 +30,7 @@ internal struct TestLogging {
     var history: History { return self.recorder }
 }
 
-internal struct TestLogHandler: LogHandler {
+internal struct TestLogHandler: LogHandler, @unchecked Sendable {
     private let logLevelLock = NSLock()
     private let metadataLock = NSLock()
     private let recorder: Recorder
@@ -96,7 +96,7 @@ internal struct TestLogHandler: LogHandler {
     }
 }
 
-internal class Config {
+internal class Config: @unchecked Sendable {
     private static let ALL = "*"
 
     private let lock = NSLock()
@@ -122,7 +122,7 @@ internal class Config {
     }
 }
 
-internal class Recorder: History {
+internal class Recorder: History, @unchecked Sendable {
     private let lock = NSLock()
     private var _entries = [LogEntry]()
 


### PR DESCRIPTION
Enforce Sendable conformance for LogHandlers Swift-Log, and make Logger Sendable. See #216 

### Motivation:

Swift-Log is adopted in many libraries, and as the language has recently involved in exciting new directions, these new features have been the subject of improvement and innovation. Many libraries aim at implementing `Sendable`, which means that many types that carry swift-log's `Logger` will quickly see warnings pop up all over these projects.

As swift-log is a loved and essential part of the swift ecosystem, it too should adopt the new Swift standards.

### Modifications:

- Require `LogHandler` implementations to conform to `Sendable`
- Conform `Logger` to `Sendable`
- Updated tests to support the new Sendable requirements

### Result:

Swift-Log supports Sendable. Requires iOS 13+, macOS 10.15+ and Swift 5.5+.
This'll obviously require a semver major.