### PR TITLE
Publicify system's default factory

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -667,7 +667,7 @@ public enum LoggingSystem {
         self._factory.replaceFactory(factory, validate: false)
     }
 
-    fileprivate static var factory: (String) -> LogHandler {
+    public static var factory: (String) -> LogHandler {
         return self._factory.underlying
     }
 


### PR DESCRIPTION
Exposes the logging system's default factory to the public.

### Motivation:

I've been using a Discord logger for my own application, and I was thinking of making it public so others can use it as well.
How it works is that i provide the `Logger` with a custom `LogHandler` which is just a skin for the 2 underlying log handlers.
The first of the two, is just a normal handler that outputs to the stdout, and the second one, is my custom Discord log handler that sends the logs to Discord. 
There are multiple reasons to use another log handler besides Discord.

* You can't fully-send too-long logs to Discord. 
* There might be a network issue. 
* Discord might just 400 your request.
* There are ratelimits that need to be respected.   

So when trying to clean things up for making it public, i figured i can use the system's default log handler as the main handler instead of just hard-coding a handler of my choice.
This is unfortunately not possible (or at least in a clean-way) since the default log handler is not accessible from either `LoggingSystem.factory()` or `Logger().handler`.

### Modifications:

Changed the `LoggingSystem`'s get-only `static var factory` from `fileprivate` to `public` .

### Result:

Custom implementations will be able to use the `LoggingSystem`'s factory too.
