### PR TITLE
[sendable] Sendable conformance checks cause errors on 5.6 but warnings on 5.7

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1276,9 +1276,14 @@ extension Logger.MetadataValue: ExpressibleByArrayLiteral {
 
 // MARK: - Sendable support helpers
 
+#if compiler(>=5.7.0)
+extension Logger.MetadataValue: Sendable {} // on 5.7 `stringConvertible`'s value marked as Sendable; but if a value not conforming to Sendable is passed there, a warning is emitted. We are okay with warnings, but on 5.6 for the same situation an error is emitted (!)
+#elseif compiler(>=5.6)
+extension Logger.MetadataValue: @unchecked Sendable {} // sadly, On 5.6 a missing Sendable conformance causes an 'error' (specifically this is about `stringConvertible`'s value)
+#endif
+
 #if compiler(>=5.6)
 extension Logger: Sendable {}
-extension Logger.MetadataValue: Sendable {}
 extension Logger.Level: Sendable {}
 extension Logger.Message: Sendable {}
 #endif

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -721,7 +721,7 @@ extension Logger {
         case string(String)
 
         /// A metadata value which is some `CustomStringConvertible`.
-        #if compiler(>=5.6)
+        #if compiler(>=5.7)
         case stringConvertible(CustomStringConvertible & Sendable)
         #else
         case stringConvertible(CustomStringConvertible)


### PR DESCRIPTION
5.6 specific follow up to https://github.com/apple/swift-log/pull/218

This would be one way to solve https://github.com/apple/swift-log/issues/228 because a missing conformance here is diagnosed as a WARNING on 5.7, but as an ERROR on 5.6.

Other checks are fine on 5.6 AFAICS though.

cc @DougGregor