### PR TITLE
RFC: Add capability to configure loggers inline

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -649,6 +649,54 @@ extension Logger {
     #endif
 }
 
+extension Logger.Metadata {
+    public struct MergingPolicy: Equatable {
+        public static var replaceValues: MergingPolicy { return .init(policy: .replaceValues) }
+        public static var retainExistingValues: MergingPolicy { return .init(policy: .retainExistingValues) }
+
+        fileprivate var policy: Policy
+        fileprivate enum Policy {
+            case replaceValues
+            case retainExistingValues
+        }
+
+        public static func ==(lhs: MergingPolicy, rhs: MergingPolicy) -> Bool {
+            return lhs.policy == rhs.policy
+        }
+    }
+}
+
+extension Logger {
+    public func makeCopy(with metadata: Metadata, mergePolicy: Metadata.MergingPolicy = .retainExistingValues) -> Logger {
+        let originalMetadata = self.handler.metadata
+        var child = self
+        child.handler.metadata = originalMetadata.merging(metadata, uniquingKeysWith: { old, new in
+            switch mergePolicy.policy {
+            case .replaceValues: return new
+            case .retainExistingValues: return old
+            }
+        })
+        return child
+    }
+
+    @inlinable
+    public func makeCopy(_ configure: (inout Logger) -> Void) -> Logger {
+        var child = self
+        configure(&child)
+        return child
+    }
+
+    public init(label: String, metadata: Metadata) {
+        self.init(label: label)
+        self.handler.metadata = metadata
+    }
+
+    public init(label: String, _ configure: (inout Logger) -> Void) {
+        self.init(label: label)
+        configure(&self)
+    }
+}
+
 /// The `LoggingSystem` is a global facility where the default logging backend implementation (`LogHandler`) can be
 /// configured. `LoggingSystem` is set up just once in a given program to set up the desired logging backend
 /// implementation.


### PR DESCRIPTION
Adds initializers and methods to create Logger instances with metadata inline.

### Motivation:

Frequently it's needed to create copies of loggers, or a new logger, with attached metadata or specific log levels, but the current method requires first creating an instance, as a `var`, and then configuring the instance.

This leaves you to have a mutable value existing in the scope even if you don't want to.

This particularly has issues with async code when capturing the instance in a `Task` because it's non-isolated

```swift
var logger = Logger(label: "\(#function)")
logger[metadataKey: metadataKey] = "original"

Task {
    logger.trace("won't work")
       // ^^^^^ Reference to captured var 'logger' in concurrently-executing code
 }
```

The best way to get around this is either

```swift
// 1 immediately invoked closure
let logger = {
    let inner = Logger(...)
    // configuration
    return inner
}()

// 2 variable rebinding
let retainedLogger = logger
Task {
    retainedLogger.trace("will work")
}

// 3 explicit capture
Task { [logger] in
    logger.trace("will also work")
}
```

### Modifications:

- Add: `makeCopy(with:mergePolicy:)` to allow just setting inline the metadata you want the new instance to have, with control on how to merge with existing metadata keys
- Add: `makeCopy(_:)` which passes an `inout` reference to the new instance, allowing you to set more options such as `logLevel` as part of creation
- Add: `init(label:metadata:)` that allows creation of instances directly inline that directly sets the metadata
- Add: `init(label:_:)` that allows creation of instances with a reference to the object for inline configuration much like `makeCopy(_:)`

### Result:

Developers will now be able to make `Logger` instances, or "children" copies, directly inline with full control over the value's mutability - making it safe to send across `Task` boundaries

```swift
let logger = Logger(label: "myLabel") {
    $0.logLevel = .info
    $0[metadataKey: "my_key"] = "my value"
}

Task {
    logger.info("this works")
}
```