### PR TITLE
Remove default implementation for protocol requirement

### DIFF
--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -134,11 +134,6 @@ public protocol LogHandler: _SwiftLogSendableLogHandler {
              function: String,
              line: UInt)
 
-    /// SwiftLog 1.0 compatibility method. Please do _not_ implement, implement
-    /// `log(level:message:metadata:source:file:function:line:)` instead.
-    @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
-    func log(level: Logging.Logger.Level, message: Logging.Logger.Message, metadata: Logging.Logger.Metadata?, file: String, function: String, line: UInt)
-
     /// Add, remove, or change the logging metadata.
     ///
     /// - note: `LogHandler`s must treat logging metadata as a value type. This means that the change in metadata must
@@ -164,19 +159,17 @@ public protocol LogHandler: _SwiftLogSendableLogHandler {
 }
 
 extension LogHandler {
-    @available(*, deprecated, message: "You should implement this method instead of using the default implementation")
-    public func log(level: Logger.Level,
-                    message: Logger.Message,
-                    metadata: Logger.Metadata?,
-                    source: String,
-                    file: String,
-                    function: String,
-                    line: UInt) {
-        self.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
-    }
-
+    
+    /// SwiftLog 1.0 compatibility method. Please do _not_ implement, implement
+    /// `log(level:message:metadata:source:file:function:line:)` instead.
     @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
-    public func log(level: Logging.Logger.Level, message: Logging.Logger.Message, metadata: Logging.Logger.Metadata?, file: String, function: String, line: UInt) {
+    public func log(
+        level: Logging.Logger.Level,
+        message: Logging.Logger.Message,
+        metadata: Logging.Logger.Metadata?,
+        file: String,
+        function: String,
+        line: UInt) {
         self.log(level: level,
                  message: message,
                  metadata: metadata,

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1171,11 +1171,16 @@ public struct StreamLogHandler: LogHandler {
 
 /// No operation LogHandler, used when no logging is required
 public struct SwiftLogNoOpLogHandler: LogHandler {
+    
     public init() {}
 
     public init(_: String) {}
 
     @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
+    
+    @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        self.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
 
     @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
         get {

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -58,6 +58,11 @@ private struct OldSchoolTestLogging {
 }
 
 private struct OldSchoolLogHandler: LogHandler {
+    
+    func log(level: Logging.Logger.Level, message: Logging.Logger.Message, metadata: Logging.Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
+        self.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
+    }
+    
     var label: String
     let config: Config
     let recorder: Recorder


### PR DESCRIPTION
The `LogHandler` protocol demands an implementation of the following.

```swift
func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt)
```

However, the compiler does not enforce this. 
This PR ensures that it does.

Fixes #248 

### Motivation:

If you do not implement the above protocol requirement, your code will crash. So the compiler should help you here.

### Modifications:

A default implementation of the protocol requirement is no longer provided.

### Result:

An error is now thrown if you do not implement this function.

<img width="815" alt="Screenshot 2023-01-10 at 04 29 17" src="https://user-images.githubusercontent.com/64097812/211462203-783653a9-b016-4715-b4b0-adc611baf77a.png">
