### PR TITLE
Allow passing explicit provider into the stream handlers

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1209,17 +1209,17 @@ public struct StreamLogHandler: LogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: LoggingSystem.metadataProvider)
     }
 
-    /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
+    /// Factory that makes a `StreamLogHandler` that directs its output to `stdout`
     public static func standardOutput(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: metadataProvider)
     }
 
-    /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
+    /// Factory that makes a `StreamLogHandler` that directs its output to `stderr`
     public static func standardError(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: LoggingSystem.metadataProvider)
     }
 
-    /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
+    /// Factory that makes a `StreamLogHandler` that direct its output to `stderr`
     public static func standardError(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: metadataProvider)
     }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1209,9 +1209,19 @@ public struct StreamLogHandler: LogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: LoggingSystem.metadataProvider)
     }
 
+    /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
+    public static func standardOutput(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: metadataProvider)
+    }
+
     /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
     public static func standardError(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: LoggingSystem.metadataProvider)
+    }
+
+    /// Factory that makes a `StreamLogHandler` to directs its output to `stderr`
+    public static func standardError(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
+        return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: metadataProvider)
     }
 
     private let stream: _SendableTextOutputStream

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -59,6 +59,7 @@ extension LoggingTest {
             ("testStdioOutputStreamWrite", testStdioOutputStreamWrite),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
             ("testOverloadingError", testOverloadingError),
+            ("testCompileInitializeStandardStreamLogHandlersWithMetadataProviders", testCompileInitializeStandardStreamLogHandlersWithMetadataProviders),
         ]
     }
 }

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -934,6 +934,30 @@ class LoggingTest: XCTestCase {
 
         logging.history.assertExist(level: .error, message: "errorDescription")
     }
+
+    func testCompileInitializeStandardStreamLogHandlersWithMetadataProviders() {
+        // avoid "unreachable code" warnings
+        let dontExecute = Int.random(in: 100 ... 200) == 1
+        guard dontExecute else {
+            return
+        }
+
+        // default usage
+        LoggingSystem.bootstrap(StreamLogHandler.standardOutput)
+        LoggingSystem.bootstrap(StreamLogHandler.standardError)
+
+        // with metadata handler, explicitly, public api
+        LoggingSystem.bootstrap({ label, metadataProvider in
+            StreamLogHandler.standardOutput(label: label, metadataProvider: metadataProvider)
+        }, metadataProvider: .exampleMetadataProvider)
+        LoggingSystem.bootstrap({ label, metadataProvider in
+            StreamLogHandler.standardError(label: label, metadataProvider: metadataProvider)
+        }, metadataProvider: .exampleMetadataProvider)
+
+        // with metadata handler, still pretty
+        LoggingSystem.bootstrap(StreamLogHandler.standardOutput, metadataProvider: .exampleMetadataProvider)
+        LoggingSystem.bootstrap(StreamLogHandler.standardError, metadataProvider: .exampleMetadataProvider)
+    }
 }
 
 extension Logger {


### PR DESCRIPTION
Small follow up to https://github.com/apple/swift-log/pull/238 which went perhaps _too_ minimal with the API additions.

Normally you don't need to customize the default stdout handler, but when you do, we made it a bit awkward right now.
It'll pick up the configured metadata provider by default, but we should follow the pattern of passing it in, also in order to allow this syntax:

```swift
        LoggingSystem.bootstrap(
            StreamLogHandler.standardOutput,
            metadataProvider: .exampleMetadataProvider)
```