### PR TITLE
Emit correct metadata from StreamLogHandler

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1287,7 +1287,7 @@ public struct StreamLogHandler: LogHandler {
             metadata.merge(explicit, uniquingKeysWith: { _, explicit in explicit })
         }
 
-        return explicit
+        return metadata
     }
 
     private func prettify(_ metadata: Logger.Metadata) -> String? {

--- a/Tests/LoggingTests/LoggingTest+XCTest.swift
+++ b/Tests/LoggingTests/LoggingTest+XCTest.swift
@@ -56,6 +56,7 @@ extension LoggingTest {
             ("testStreamLogHandlerOutputFormat", testStreamLogHandlerOutputFormat),
             ("testStreamLogHandlerOutputFormatWithMetaData", testStreamLogHandlerOutputFormatWithMetaData),
             ("testStreamLogHandlerOutputFormatWithOrderedMetadata", testStreamLogHandlerOutputFormatWithOrderedMetadata),
+            ("testStreamLogHandlerWritesIncludeMetadataProviderMetadata", testStreamLogHandlerWritesIncludeMetadataProviderMetadata),
             ("testStdioOutputStreamWrite", testStdioOutputStreamWrite),
             ("testStdioOutputStreamFlush", testStdioOutputStreamFlush),
             ("testOverloadingError", testOverloadingError),


### PR DESCRIPTION
Return the correct metadata to log from the `StreamLogHandler`.

### Motivation:

At the moment, `StreamLogHandler` always returns the explicitly passed metadata as the metadata to log. This throws away any metadata provided by the registered `MetadataProvider`.

### Modifications:

Return the merged metadata, both explicit and provided.

### Result:

When using the `StreamLogHandler`, metadata set through `MetadataProvider`s will now correctly show up in the logs.