### PR TITLE
Avoid logging warnings when handler does not support metadataproviders

### DIFF
--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -177,7 +177,11 @@ extension LogHandler {
             nil
         }
         set {
-            self.log(level: .warning, message: "Attempted to set metadataProvider on \(Self.self) that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", metadata: nil, source: "Logging", file: #file, function: #function, line: #line)
+            #if DEBUG
+            if LoggingSystem.warnOnceLogHandlerNotSupportedMetadataProvider(Self.self) {
+                self.log(level: .warning, message: "Attempted to set metadataProvider on \(Self.self) that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", metadata: nil, source: "Logging", file: #file, function: #function, line: #line)
+            }
+            #endif
         }
     }
 }

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -663,6 +663,10 @@ public enum LoggingSystem {
     private static let _factory = FactoryBox { label, _ in StreamLogHandler.standardOutput(label: label) }
     private static let _metadataProviderFactory = MetadataProviderBox(nil)
 
+    #if DEBUG
+    private static var _warnOnceBox: WarnOnceBox = WarnOnceBox()
+    #endif
+
     /// `bootstrap` is a one-time configuration function which globally selects the desired logging backend
     /// implementation. `bootstrap` can be called at maximum once in any given program, calling it more than once will
     /// lead to undefined behavior, most likely a crash.
@@ -708,7 +712,7 @@ public enum LoggingSystem {
 
     fileprivate static var factory: (String, Logger.MetadataProvider?) -> LogHandler {
         return { label, metadataProvider in
-            return self._factory.underlying(label, metadataProvider)
+            self._factory.underlying(label, metadataProvider)
         }
     }
 
@@ -724,6 +728,15 @@ public enum LoggingSystem {
     public static var metadataProvider: Logger.MetadataProvider? {
         return self._metadataProviderFactory.metadataProvider
     }
+
+    #if DEBUG
+    /// Used to warn only once about a specific ``LogHandler`` type when it does not support ``Logger/MetadataProvider``,
+    /// but an attempt was made to set a metadata provider on such handler. In order to avoid flooding the system with
+    /// warnings such warning is only emitted in debug mode, and even then at-most once for a handler type.
+    internal static func warnOnceLogHandlerNotSupportedMetadataProvider<Handler: LogHandler>(_ type: Handler.Type) -> Bool {
+        self._warnOnceBox.warnOnceLogHandlerNotSupportedMetadataProvider(type: type)
+    }
+    #endif
 
     private final class FactoryBox {
         private let lock = ReadWriteLock()
@@ -1436,6 +1449,28 @@ extension Logger.MetadataValue: ExpressibleByArrayLiteral {
         self = .array(elements)
     }
 }
+
+// MARK: - Debug only warnings
+
+#if DEBUG
+/// Contains state to manage all kinds of "warn only once" warnings which the logging system may want to issue.
+private final class WarnOnceBox {
+    private let lock: Lock = Lock()
+    private var warnOnceLogHandlerNotSupportedMetadataProviderPerType: [ObjectIdentifier: Bool] = [:]
+
+    func warnOnceLogHandlerNotSupportedMetadataProvider<Handler: LogHandler>(type: Handler.Type) -> Bool {
+        self.lock.withLock {
+            let id = ObjectIdentifier(type)
+            if warnOnceLogHandlerNotSupportedMetadataProviderPerType[id] ?? false {
+                return false // don't warn, it was already warned about
+            } else {
+                warnOnceLogHandlerNotSupportedMetadataProviderPerType[id] = true
+                return true // warn about this handler type, it is the first time we encountered it
+            }
+        }
+    }
+}
+#endif
 
 // MARK: - Sendable support helpers
 

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -708,9 +708,7 @@ public enum LoggingSystem {
 
     fileprivate static var factory: (String, Logger.MetadataProvider?) -> LogHandler {
         return { label, metadataProvider in
-            var handler = self._factory.underlying(label, metadataProvider)
-            handler.metadataProvider = metadataProvider
-            return handler
+            return self._factory.underlying(label, metadataProvider)
         }
     }
 

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -25,7 +25,9 @@ import Glibc
 final class MetadataProviderTest: XCTestCase {
     func testLoggingMergesOneOffMetadataWithProvidedMetadataFromExplicitlyPassed() throws {
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal(logging.makeWithMetadataProvider,
+            metadataProvider: .init {["common": "initial"]
+        })
 
         let logger = Logger(label: #function, metadataProvider: .init {
             [

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -26,7 +26,7 @@ final class MetadataProviderTest: XCTestCase {
     func testLoggingMergesOneOffMetadataWithProvidedMetadataFromExplicitlyPassed() throws {
         let logging = TestLogging()
         LoggingSystem.bootstrapInternal(logging.makeWithMetadataProvider,
-            metadataProvider: .init {["common": "initial"]
+                                        metadataProvider: .init { ["common": "initial"]
         })
 
         let logger = Logger(label: #function, metadataProvider: .init {
@@ -44,21 +44,31 @@ final class MetadataProviderTest: XCTestCase {
     }
 
     func testLogHandlerThatDidNotImplementProvidersButSomeoneAttemptsToSetOneOnIt() {
+        #if DEBUG
+        // we only emit these warnings in debug mode
         let logging = TestLogging()
         var handler = LogHandlerThatDidNotImplementMetadataProviders(testLogging: logging)
 
         handler.metadataProvider = .simpleTestProvider
 
         logging.history.assertExist(level: .warning, message: "Attempted to set metadataProvider on LogHandlerThatDidNotImplementMetadataProviders that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", source: "Logging")
+
+        let countBefore = logging.history.entries.count
+        handler.metadataProvider = .simpleTestProvider
+        XCTAssertEqual(countBefore, logging.history.entries.count, "Should only log the warning once")
+        #endif
     }
 
     func testLogHandlerThatDidImplementProvidersButSomeoneAttemptsToSetOneOnIt() {
+        #if DEBUG
+        // we only emit these warnings in debug mode
         let logging = TestLogging()
         var handler = LogHandlerThatDidImplementMetadataProviders(testLogging: logging)
 
         handler.metadataProvider = .simpleTestProvider
 
         logging.history.assertNotExist(level: .warning, message: "Attempted to set metadataProvider on LogHandlerThatDidImplementMetadataProviders that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", source: "Logging")
+        #endif
     }
 }
 


### PR DESCRIPTION
Discovered by https://github.com/vapor/console-kit/pull/177

---

We were setting the metadata provider "always" so even without implementing the right factory function it would have tried to set a provider during logger creation. Since this happens in code which did not adopt metadata providers, it ends up as logging a warning for creating loggers.

This can be very noisy, e.g. a plain new vapor project would be like this:

```
[1357/1357] Linking Run
Build complete! (47.19s)
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
[ NOTICE ] Server starting on http://127.0.0.1:8080
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
[ INFO ] GET / [request-id: AAF6BC94-109E-4492-B061-F26B4060DC9F]
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
[ WARNING ] Attempted to set metadataProvider on ConsoleLogger that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.
```

The change in https://github.com/apple/swift-log/commit/6f9b9d4cd7cce207b5256adb5ac6fc4c7f6e9040 here makes it such that the only way to make use of metadata providers is to make sure to bootstrap with a factory that accepts one. OR you can always set it manually later on, if you know your log handler will support it.

This avoids the noisy logging.

The warning logging still would happen here if you do yourself 

```
log.metadataProvider = ....
```

on a log handler that does not support it. I think this is fine (?), but it would happen for every instance of such call... 

I could be convinced to remove the warning entirely if we think this is still risking it too much.

---


For context, the origin of the warning is this:

```
extension LogHandler {
    /// Default implementation for `metadataProvider` which defaults to `nil`.
    /// This default exists in order to facilitate source-compatible introduction of the `metadataProvider` protocol requirement.
    public var metadataProvider: Logger.MetadataProvider? {
        get {
            nil
        }
        set {
            self.log(level: .warning, message: "Attempted to set metadataProvider on \(Self.self) that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.", metadata: nil, source: "Logging", file: #file, function: #function, line: #line)
        }
    }
}
```

so if someone tried to set a provider on a logger whose handler does not support it, the intent was to give a warning.