### PR TITLE
Update CI

### DIFF
--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -3,17 +3,16 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-log:20.04-5.8
+    image: swift-log:22.04-5.9
     build:
       args:
-        ubuntu_version: "focal"
-        swift_version: "5.8"
+        base_image: "swiftlang/swift:nightly-5.9-jammy"
 
   test:
-    image: swift-log:20.04-5.8
+    image: swift-log:22.04-5.9
     environment:
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:
-    image: swift-log:20.04-5.8
+    image: swift-log:22.04-5.9


### PR DESCRIPTION
- Swift 5.8 docker images are available
- Add docker-compose file for Swift 5.9
