### PR TITLE
Use #if canImport(Darwin) where possible

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import Darwin
 #elseif os(Windows)
 import CRT
@@ -1242,7 +1242,7 @@ internal struct StdioOutputStream: TextOutputStream {
 }
 
 // Prevent name clashes
-#if os(macOS) || os(tvOS) || os(iOS) || os(watchOS)
+#if canImport(Darwin)
 let systemStderr = Darwin.stderr
 let systemStdout = Darwin.stdout
 #elseif os(Windows)

--- a/Sources/Logging/MetadataProvider.swift
+++ b/Sources/Logging/MetadataProvider.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import Darwin
 #elseif os(Windows)
 import CRT

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -14,7 +14,7 @@
 @testable import Logging
 import XCTest
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import Darwin
 #elseif os(Windows)
 import WinSDK

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -14,7 +14,7 @@
 @testable import Logging
 import XCTest
 
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if canImport(Darwin)
 import Darwin
 #elseif os(Windows)
 import WinSDK

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -359,7 +359,7 @@ public class MDC {
     }
 
     private var threadId: Int {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if canImport(Darwin)
         return Int(pthread_mach_thread_np(pthread_self()))
         #elseif os(Windows)
         return Int(GetCurrentThreadId())


### PR DESCRIPTION
### Motivation:

Instead of adding every Darwin OS we should rather check if we can import `Darwin`
