### PR TITLE
Changes to build with Musl.

### DIFF
--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -34,6 +34,8 @@ import Darwin
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #else
 #error("Unsupported runtime")
 #endif

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -18,6 +18,8 @@ import Darwin
 import CRT
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WASILibc)
 import WASILibc
 #else
@@ -1251,6 +1253,9 @@ let systemStdout = CRT.stdout
 #elseif canImport(Glibc)
 let systemStderr = Glibc.stderr!
 let systemStdout = Glibc.stdout!
+#elseif canImport(Musl)
+let systemStderr = Musl.stderr!
+let systemStdout = Musl.stdout!
 #elseif canImport(WASILibc)
 let systemStderr = WASILibc.stderr!
 let systemStdout = WASILibc.stdout!

--- a/Sources/Logging/MetadataProvider.swift
+++ b/Sources/Logging/MetadataProvider.swift
@@ -18,6 +18,8 @@ import Darwin
 import CRT
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(WASILibc)
 import WASILibc
 #else


### PR DESCRIPTION
Added imports of Musl in a few places.  Also added definitions for `systemStderr` and `systemStdout`.

### Motivation:

We would like to be able to build swift-log on top of Musl, as well as the usual Glibc.

### Modifications:

Really just adds some `import Musl`s in conditionals, alongside the `import Glibc`s.

### Result:

swift-log will build against Musl.
