### PR TITLE
Explicitly set the type of the SPM library to be dynamic.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     targets: [
         .target(

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     targets: [
         .target(

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     targets: [
         .target(

--- a/Package@swift-5.4.swift
+++ b/Package@swift-5.4.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     targets: [
         .target(

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "Logging", type: .dynamic, targets: ["Logging"]),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Explicitly set the type of the SPM library to be dynamic.

Motivation:

When a binary target-type framework consumer specifies swift-log as a transitive dependency, the swift-log symbols that the framework depends on are statically linked in that framework's binary. As a result, consumers of said framework resolve the swift-log transitive dependency which is made available as a dynamic library at runtime - meaning duplicate symbols are present in two (or more) different dynamic libraries causing "Class is implemented in both..." warning logs.

Downstream app warning logs at runtime:
![image](https://github.com/apple/swift-log/assets/55437880/adac708e-0bb9-4855-8adb-b70c2fa5180b)

Proof of swift-log symbols being statically linked in my binary framework consumer:
![image](https://github.com/apple/swift-log/assets/55437880/8477ea7a-fefd-49f8-bb7f-5571d4dee65a)

Modifications:

To resolve this, I have explicitly set the SPM library type of swift-log to 'dynamic'. This means binary target-type consumers link swift-log dynamically.

Result:

Binary target-type framework consumers of swift-log will get the same experience as regular source-code consumers of swift-log as swift-log will be linked dynamically rather than statically.

I've tried and tested this fork in an app which resolves my binary target-type framework through SPM and swift-log (as a transitive dependency) and I no longer get those warnings.

Proof of swift-log symbols no longer being statically linked to binary target-type consumers after my change:
![image](https://github.com/apple/swift-log/assets/55437880/7aafc1a8-94e9-4131-ae5d-aeee67c358e4)
