### PR TITLE
patch: Replace standardOutput to standardError

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -662,7 +662,7 @@ extension Logger {
 /// configured. `LoggingSystem` is set up just once in a given program to set up the desired logging backend
 /// implementation.
 public enum LoggingSystem {
-    private static let _factory = FactoryBox { label, _ in StreamLogHandler.standardOutput(label: label) }
+    private static let _factory = FactoryBox { label, _ in StreamLogHandler.standardError(label: label) }
     private static let _metadataProviderFactory = MetadataProviderBox(nil)
 
     #if DEBUG


### PR DESCRIPTION
This change updates SwiftLog to direct log messages to the standard error stream (stderr) instead of the standard output stream (stdout).

### Motivation:

Standard output is used to print the results from the program to the output, while standard error is used to print the error stream separately. The change also increases readability of logs by keeping them separate from regular output.

### Modifications:

 I changed the initialization of the _factory property from using `StreamLogHandler.standardOutput` to `StreamLogHandler.standardError`

### Result:

After this change, log messages produced by SwiftLog will be directed to the standard error stream (stderr) instead of the standard output stream (stdout).