### PR TITLE
Make protocol usage obvious using any and some keywords

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+    .enableUpcomingFeature("ExistentialAny"),
+]
+
 let package = Package(
     name: "swift-log",
     products: [
@@ -26,11 +30,13 @@ let package = Package(
     targets: [
         .target(
             name: "Logging",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: swiftSettings
         ),
         .testTarget(
             name: "LoggingTests",
-            dependencies: ["Logging"]
+            dependencies: ["Logging"],
+            swiftSettings: swiftSettings
         ),
     ]
 )

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -45,7 +45,7 @@ private struct OldSchoolTestLogging {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 
-    func make(label: String) -> LogHandler {
+    func make(label: String) -> any LogHandler {
         return OldSchoolLogHandler(label: label,
                                    config: self.config,
                                    recorder: self.recorder,
@@ -54,7 +54,7 @@ private struct OldSchoolTestLogging {
     }
 
     var config: Config { return self._config }
-    var history: History { return self.recorder }
+    var history: some History { return self.recorder }
 }
 
 private struct OldSchoolLogHandler: LogHandler {
@@ -62,7 +62,7 @@ private struct OldSchoolLogHandler: LogHandler {
     let config: Config
     let recorder: Recorder
 
-    func make(label: String) -> LogHandler {
+    func make(label: String) -> some LogHandler {
         return TestLogHandler(label: label, config: self.config, recorder: self.recorder)
     }
 

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -1056,7 +1056,7 @@ class LoggingTest: XCTestCase {
 }
 
 extension Logger {
-    public func error(error: Error,
+    public func error(error: any Error,
                       metadata: @autoclosure () -> Logger.Metadata? = nil,
                       file: String = #fileID, function: String = #function, line: UInt = #line) {
         self.error("\(error.localizedDescription)", metadata: metadata(), file: file, function: function, line: line)

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -22,7 +22,7 @@ internal struct TestLogging {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 
-    func make(label: String) -> LogHandler {
+    func make(label: String) -> some LogHandler {
         return TestLogHandler(
             label: label,
             config: self.config,
@@ -31,7 +31,7 @@ internal struct TestLogging {
         )
     }
 
-    func makeWithMetadataProvider(label: String, metadataProvider: Logger.MetadataProvider?) -> LogHandler {
+    func makeWithMetadataProvider(label: String, metadataProvider: Logger.MetadataProvider?) -> (some LogHandler) {
         return TestLogHandler(
             label: label,
             config: self.config,
@@ -41,7 +41,7 @@ internal struct TestLogging {
     }
 
     var config: Config { return self._config }
-    var history: History { return self.recorder }
+    var history: some History { return self.recorder }
 }
 
 internal struct TestLogHandler: LogHandler {


### PR DESCRIPTION
Motivation:

Calling through protocols is more expensive than many other types of call.

Modifications:

Annotate each protocol usage with any or some keywords.

Result:

Protocol usage now obvious