### PR TITLE
Add Sendability annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
+    .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
 ]
 
 let package = Package(

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -46,7 +46,7 @@ import Musl
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
-internal final class Lock {
+internal final class Lock: @unchecked Sendable {
     #if canImport(WASILibc)
     // WASILibc is single threaded, provides no locks
     #elseif os(Windows)
@@ -148,7 +148,7 @@ extension Lock {
 /// of lock is safe to use with `libpthread`-based threading models, such as the
 /// one used by NIO. On Windows, the lock is based on the substantially similar
 /// `SRWLOCK` type.
-internal final class ReadWriteLock {
+internal final class ReadWriteLock: @unchecked Sendable {
     #if canImport(WASILibc)
     // WASILibc is single threaded, provides no locks
     #elseif os(Windows)
@@ -189,7 +189,7 @@ internal final class ReadWriteLock {
     ///
     /// Whenever possible, consider using `withReaderLock` instead of this
     /// method and `unlock`, to simplify lock handling.
-    public func lockRead() {
+    fileprivate func lockRead() {
         #if canImport(WASILibc)
         // WASILibc is single threaded, provides no locks
         #elseif os(Windows)
@@ -205,7 +205,7 @@ internal final class ReadWriteLock {
     ///
     /// Whenever possible, consider using `withWriterLock` instead of this
     /// method and `unlock`, to simplify lock handling.
-    public func lockWrite() {
+    fileprivate func lockWrite() {
         #if canImport(WASILibc)
         // WASILibc is single threaded, provides no locks
         #elseif os(Windows)
@@ -222,7 +222,7 @@ internal final class ReadWriteLock {
     /// Whenever possible, consider using `withReaderLock` and `withWriterLock`
     /// instead of this method and `lockRead` and `lockWrite`, to simplify lock
     /// handling.
-    public func unlock() {
+    fileprivate func unlock() {
         #if canImport(WASILibc)
         // WASILibc is single threaded, provides no locks
         #elseif os(Windows)

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -17,7 +17,11 @@ import Darwin
 #elseif os(Windows)
 import CRT
 #elseif canImport(Glibc)
+#if compiler(>=6.0)
 @preconcurrency import Glibc
+#else
+import Glibc
+#endif
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -517,7 +517,7 @@ public enum LoggingSystem {
     /// - parameters:
     ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.
     @preconcurrency
-    public static func bootstrap(_ factory: @escaping @Sendable (String) -> any LogHandler) {
+    public static func bootstrap(_ factory: @escaping @Sendable(String) -> any LogHandler) {
         self._factory.replace({ label, _ in
             factory(label)
         }, validate: true)
@@ -534,14 +534,14 @@ public enum LoggingSystem {
     ///     - metadataProvider: The `MetadataProvider` used to inject runtime-generated metadata from the execution context.
     ///     - factory: A closure that given a `Logger` identifier, produces an instance of the `LogHandler`.
     @preconcurrency
-    public static func bootstrap(_ factory: @escaping @Sendable (String, Logger.MetadataProvider?) -> any LogHandler,
+    public static func bootstrap(_ factory: @escaping @Sendable(String, Logger.MetadataProvider?) -> any LogHandler,
                                  metadataProvider: Logger.MetadataProvider?) {
         self._metadataProviderFactory.replace(metadataProvider, validate: true)
         self._factory.replace(factory, validate: true)
     }
 
     // for our testing we want to allow multiple bootstrapping
-    internal static func bootstrapInternal(_ factory: @escaping @Sendable (String) -> any LogHandler) {
+    internal static func bootstrapInternal(_ factory: @escaping @Sendable(String) -> any LogHandler) {
         self._metadataProviderFactory.replace(nil, validate: false)
         self._factory.replace({ label, _ in
             factory(label)
@@ -549,7 +549,7 @@ public enum LoggingSystem {
     }
 
     // for our testing we want to allow multiple bootstrapping
-    internal static func bootstrapInternal(_ factory: @escaping @Sendable (String, Logger.MetadataProvider?) -> any LogHandler,
+    internal static func bootstrapInternal(_ factory: @escaping @Sendable(String, Logger.MetadataProvider?) -> any LogHandler,
                                            metadataProvider: Logger.MetadataProvider?) {
         self._metadataProviderFactory.replace(metadataProvider, validate: false)
         self._factory.replace(factory, validate: false)
@@ -594,13 +594,13 @@ public enum LoggingSystem {
 
         func withReadLock<Result>(_ operation: (Value) -> Result) -> Result {
             self.lock.withReaderLock {
-                return operation(self.storage)
+                operation(self.storage)
             }
         }
 
         func withWriteLock<Result>(_ operation: (inout Value) -> Result) -> Result {
             self.lock.withWriterLock {
-                return operation(&self.storage)
+                operation(&self.storage)
             }
         }
     }
@@ -645,7 +645,7 @@ public enum LoggingSystem {
         }
     }
 
-    private typealias FactoryBox = ReplaceOnceBox<@Sendable (_ label: String, _ provider: Logger.MetadataProvider?) -> any LogHandler>
+    private typealias FactoryBox = ReplaceOnceBox< @Sendable(_ label: String, _ provider: Logger.MetadataProvider?) -> any LogHandler>
 
     private typealias MetadataProviderBox = ReplaceOnceBox<Logger.MetadataProvider?>
 }
@@ -1103,6 +1103,7 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
         #endif
         return StdioOutputStream(file: systemStderr, flushMode: .always)
     }()
+
     internal static let stdout = {
         // Prevent name clashes
         #if canImport(Darwin)

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1144,25 +1144,21 @@ public struct StreamLogHandler: LogHandler {
     internal typealias _SendableTextOutputStream = TextOutputStream & Sendable
 
     /// Factory that makes a `StreamLogHandler` to directs its output to `stdout`
-    @Sendable
     public static func standardOutput(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: LoggingSystem.metadataProvider)
     }
 
     /// Factory that makes a `StreamLogHandler` that directs its output to `stdout`
-    @Sendable
     public static func standardOutput(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stdout, metadataProvider: metadataProvider)
     }
 
     /// Factory that makes a `StreamLogHandler` that directs its output to `stderr`
-    @Sendable
     public static func standardError(label: String) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: LoggingSystem.metadataProvider)
     }
 
     /// Factory that makes a `StreamLogHandler` that direct its output to `stderr`
-    @Sendable
     public static func standardError(label: String, metadataProvider: Logger.MetadataProvider?) -> StreamLogHandler {
         return StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: metadataProvider)
     }

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -19,7 +19,7 @@ final class CompatibilityTest: XCTestCase {
     func testAllLogLevelsWorkWithOldSchoolLogHandlerWorks() {
         let testLogging = OldSchoolTestLogging()
 
-        var logger = Logger(label: "\(#function)", factory: testLogging.make)
+        var logger = Logger(label: "\(#function)", factory: { testLogging.make(label: $0) })
         logger.logLevel = .trace
 
         logger.trace("yes: trace")

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -23,7 +23,7 @@ class GlobalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.debug)
@@ -50,7 +50,7 @@ class GlobalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)
@@ -77,7 +77,7 @@ class GlobalLoggerTest: XCTestCase {
     func test3() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // change test logging config
         logging.config.set(value: .warning)

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -13,6 +13,11 @@
 //===----------------------------------------------------------------------===//
 @testable import Logging
 import XCTest
+#if compiler(>=6.0) || canImport(Darwin)
+import Dispatch
+#else
+@preconcurrency import Dispatch
+#endif
 
 class GlobalLoggerTest: XCTestCase {
     func test1() throws {

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -23,7 +23,7 @@ class LocalLoggerTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // change test logging config to log traces and above
         logging.config.set(value: Logger.Level.debug)
@@ -51,7 +51,7 @@ class LocalLoggerTest: XCTestCase {
     func test2() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // change test logging config to log errors and above
         logging.config.set(value: Logger.Level.error)

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -13,6 +13,11 @@
 //===----------------------------------------------------------------------===//
 @testable import Logging
 import XCTest
+#if compiler(>=6.0) || canImport(Darwin)
+import Dispatch
+#else
+@preconcurrency import Dispatch
+#endif
 
 class LocalLoggerTest: XCTestCase {
     func test1() throws {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -22,7 +22,7 @@ import WinSDK
 import Glibc
 #endif
 
-fileprivate extension LogHandler {
+private extension LogHandler {
     func with(logLevel: Logger.Level) -> any LogHandler {
         var result = self
         result.logLevel = logLevel
@@ -711,7 +711,7 @@ class LoggingTest: XCTestCase {
         private let lock = Lock()
         private var storage: Value
 
-        init(initialValue:  Value) {
+        init(initialValue: Value) {
             self.storage = initialValue
         }
 
@@ -721,15 +721,15 @@ class LoggingTest: XCTestCase {
             }
         }
 
-        func withLockMutating(_ operation: (inout Value) -> Void) -> Void {
+        func withLockMutating(_ operation: (inout Value) -> Void) {
             self.lock.withLockVoid {
                 operation(&self.storage)
             }
         }
 
         var underlying: Value {
-            get { self.withLock { return $0 } }
-            set { self.withLockMutating { $0 = newValue }}
+            get { self.withLock { $0 } }
+            set { self.withLockMutating { $0 = newValue } }
         }
     }
 

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -1066,8 +1066,8 @@ class LoggingTest: XCTestCase {
         }
 
         // default usage
-        LoggingSystem.bootstrap({ (label: String) in StreamLogHandler.standardOutput(label: label) })
-        LoggingSystem.bootstrap({ (label: String) in StreamLogHandler.standardError(label: label) })
+        LoggingSystem.bootstrap { (label: String) in StreamLogHandler.standardOutput(label: label) }
+        LoggingSystem.bootstrap { (label: String) in StreamLogHandler.standardError(label: label) }
 
         // with metadata handler, explicitly, public api
         LoggingSystem.bootstrap({ label, metadataProvider in

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -1066,8 +1066,8 @@ class LoggingTest: XCTestCase {
         }
 
         // default usage
-        LoggingSystem.bootstrap(StreamLogHandler.standardOutput)
-        LoggingSystem.bootstrap(StreamLogHandler.standardError)
+        LoggingSystem.bootstrap({ (label: String) in StreamLogHandler.standardOutput(label: label) })
+        LoggingSystem.bootstrap({ (label: String) in StreamLogHandler.standardError(label: label) })
 
         // with metadata handler, explicitly, public api
         LoggingSystem.bootstrap({ label, metadataProvider in
@@ -1078,8 +1078,10 @@ class LoggingTest: XCTestCase {
         }, metadataProvider: .exampleMetadataProvider)
 
         // with metadata handler, still pretty
-        LoggingSystem.bootstrap(StreamLogHandler.standardOutput, metadataProvider: .exampleMetadataProvider)
-        LoggingSystem.bootstrap(StreamLogHandler.standardError, metadataProvider: .exampleMetadataProvider)
+        LoggingSystem.bootstrap({ (label: String, metadataProvider: Logger.MetadataProvider?) in StreamLogHandler.standardOutput(label: label, metadataProvider: metadataProvider) },
+                                metadataProvider: .exampleMetadataProvider)
+        LoggingSystem.bootstrap({ (label: String, metadataProvider: Logger.MetadataProvider?) in StreamLogHandler.standardError(label: label, metadataProvider: metadataProvider) },
+                                metadataProvider: .exampleMetadataProvider)
     }
 
     func testLoggerIsJustHoldingASinglePointer() {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -40,7 +40,7 @@ class LoggingTest: XCTestCase {
     func testAutoclosure() throws {
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         var logger = Logger(label: "test")
         logger.logLevel = .info
@@ -327,7 +327,7 @@ class LoggingTest: XCTestCase {
 
     func testDictionaryMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger[metadataKey: "foo"] = ["bar": "buz"]
@@ -343,7 +343,7 @@ class LoggingTest: XCTestCase {
 
     func testListMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger[metadataKey: "foo"] = ["bar", "buz"]
@@ -386,7 +386,7 @@ class LoggingTest: XCTestCase {
 
     func testStringConvertibleMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
         var logger = Logger(label: "\(#function)")
 
         logger[metadataKey: "foo"] = .stringConvertible("raw-string")
@@ -406,7 +406,7 @@ class LoggingTest: XCTestCase {
 
     func testAutoClosuresAreNotForcedUnlessNeeded() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .error
@@ -420,7 +420,7 @@ class LoggingTest: XCTestCase {
 
     func testLocalMetadata() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.info("hello world!", metadata: ["foo": "bar"])
@@ -461,7 +461,7 @@ class LoggingTest: XCTestCase {
 
     func testAllLogLevelsExceptCriticalCanBeBlocked() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .critical
@@ -485,7 +485,7 @@ class LoggingTest: XCTestCase {
 
     func testAllLogLevelsWork() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .trace
@@ -509,7 +509,7 @@ class LoggingTest: XCTestCase {
 
     func testAllLogLevelByFunctionRefWithSource() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .trace
@@ -541,7 +541,7 @@ class LoggingTest: XCTestCase {
 
     func testAllLogLevelByFunctionRefWithoutSource() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .trace
@@ -573,7 +573,7 @@ class LoggingTest: XCTestCase {
 
     func testLogsEmittedFromSubdirectoryGetCorrectModuleInNewerSwifts() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .trace
@@ -593,7 +593,7 @@ class LoggingTest: XCTestCase {
 
     func testLogMessageWithStringInterpolation() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .debug
@@ -606,7 +606,7 @@ class LoggingTest: XCTestCase {
 
     func testLoggingAString() {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         var logger = Logger(label: "\(#function)")
         logger.logLevel = .debug
@@ -1049,7 +1049,7 @@ class LoggingTest: XCTestCase {
         }
         // bootstrap with our test logging impl
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         var logger = Logger(label: "test")
         logger.logLevel = .error

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -639,9 +639,8 @@ class LoggingTest: XCTestCase {
 
     func testLoggerWithoutFactoryOverrideDefaultsToUsingLoggingSystemMetadataProvider() {
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal({ label, metadataProvider in
-            logging.makeWithMetadataProvider(label: label, metadataProvider: metadataProvider)
-        }, metadataProvider: .init { ["provider": "42"] })
+        LoggingSystem.bootstrapInternal({ logging.makeWithMetadataProvider(label: $0, metadataProvider: $1) },
+                                        metadataProvider: .init { ["provider": "42"] })
 
         let logger = Logger(label: #function)
 
@@ -655,7 +654,7 @@ class LoggingTest: XCTestCase {
     func testLoggerWithPredefinedLibraryMetadataProvider() {
         let logging = TestLogging()
         LoggingSystem.bootstrapInternal(
-            logging.makeWithMetadataProvider,
+            { logging.makeWithMetadataProvider(label: $0, metadataProvider: $1) },
             metadataProvider: .exampleMetadataProvider
         )
 
@@ -670,7 +669,8 @@ class LoggingTest: XCTestCase {
 
     func testLoggerWithFactoryOverrideDefaultsToUsingLoggingSystemMetadataProvider() {
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.makeWithMetadataProvider, metadataProvider: .init { ["provider": "42"] })
+        LoggingSystem.bootstrapInternal({ logging.makeWithMetadataProvider(label: $0, metadataProvider: $1) },
+                                        metadataProvider: .init { ["provider": "42"] })
 
         let logger = Logger(label: #function, factory: { label in
             logging.makeWithMetadataProvider(label: label, metadataProvider: LoggingSystem.metadataProvider)

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if compiler(>=6.0) || canImport(Darwin)
 import Dispatch
+#else
+@preconcurrency import Dispatch
+#endif
 @testable import Logging
 import XCTest
 

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -11,11 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if compiler(>=6.0) || canImport(Darwin)
 import Dispatch
-#else
-@preconcurrency import Dispatch
-#endif
 @testable import Logging
 import XCTest
 

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -19,7 +19,7 @@ class MDCTest: XCTestCase {
     func test1() throws {
         // bootstrap with our test logger
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.make)
+        LoggingSystem.bootstrapInternal { logging.make(label: $0) }
 
         // run the program
         MDC.global["foo"] = "bar"

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -25,7 +25,7 @@ import Glibc
 final class MetadataProviderTest: XCTestCase {
     func testLoggingMergesOneOffMetadataWithProvidedMetadataFromExplicitlyPassed() throws {
         let logging = TestLogging()
-        LoggingSystem.bootstrapInternal(logging.makeWithMetadataProvider,
+        LoggingSystem.bootstrapInternal({ logging.makeWithMetadataProvider(label: $0, metadataProvider: $1) },
                                         metadataProvider: .init { ["common": "initial"]
         })
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -22,6 +22,7 @@ internal struct TestLogging {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 
+    @Sendable
     func make(label: String) -> some LogHandler {
         return TestLogHandler(
             label: label,
@@ -31,6 +32,7 @@ internal struct TestLogging {
         )
     }
 
+    @Sendable
     func makeWithMetadataProvider(label: String, metadataProvider: Logger.MetadataProvider?) -> (some LogHandler) {
         return TestLogHandler(
             label: label,
@@ -276,7 +278,7 @@ public class MDC {
     private let lock = NSLock()
     private var storage = [Int: Logger.Metadata]()
 
-    public static var global = MDC()
+    public static let global = MDC()
 
     private init() {}
 
@@ -362,7 +364,7 @@ internal struct TestLibrary {
         self.logger.info("TestLibrary::doSomething")
     }
 
-    public func doSomethingAsync(completion: @escaping () -> Void) {
+    public func doSomethingAsync(completion: @escaping @Sendable () -> Void) {
         // libraries that use global loggers and async, need to make sure they propagate the
         // logging metadata when creating a new thread
         let metadata = MDC.global.metadata

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -17,6 +17,11 @@ import XCTest
 #if os(Windows)
 import WinSDK
 #endif
+#if compiler(>=6.0) || canImport(Darwin)
+import Dispatch
+#else
+@preconcurrency import Dispatch
+#endif
 
 internal struct TestLogging {
     private let _config = Config() // shared among loggers
@@ -354,7 +359,7 @@ internal extension NSLock {
     }
 }
 
-internal struct TestLibrary {
+internal struct TestLibrary: Sendable {
     private let logger = Logger(label: "TestLibrary")
     private let queue = DispatchQueue(label: "TestLibrary")
 

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -27,7 +27,6 @@ internal struct TestLogging {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 
-    @Sendable
     func make(label: String) -> some LogHandler {
         return TestLogHandler(
             label: label,
@@ -37,7 +36,6 @@ internal struct TestLogging {
         )
     }
 
-    @Sendable
     func makeWithMetadataProvider(label: String, metadataProvider: Logger.MetadataProvider?) -> (some LogHandler) {
         return TestLogHandler(
             label: label,

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -364,7 +364,7 @@ internal struct TestLibrary {
         self.logger.info("TestLibrary::doSomething")
     }
 
-    public func doSomethingAsync(completion: @escaping @Sendable () -> Void) {
+    public func doSomethingAsync(completion: @escaping @Sendable() -> Void) {
         // libraries that use global loggers and async, need to make sure they propagate the
         // logging metadata when creating a new thread
         let metadata = MDC.global.metadata

--- a/Tests/LoggingTests/TestSendable.swift
+++ b/Tests/LoggingTests/TestSendable.swift
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import Dispatch
 @testable import Logging
 import XCTest
 

--- a/Tests/LoggingTests/TestSendable.swift
+++ b/Tests/LoggingTests/TestSendable.swift
@@ -17,7 +17,7 @@ import XCTest
 class SendableTest: XCTestCase {
     func testSendableLogger() async {
         let testLogging = TestLogging()
-        LoggingSystem.bootstrapInternal(testLogging.make)
+        LoggingSystem.bootstrapInternal { testLogging.make(label: $0) }
 
         let logger = Logger(label: "test")
         let message1 = Logger.Message(stringLiteral: "critical 1")

--- a/docker/docker-compose.2004.58.yaml
+++ b/docker/docker-compose.2004.58.yaml
@@ -12,7 +12,6 @@ services:
   test:
     image: swift-log:20.04-5.8
     environment:
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2004.58.yaml
+++ b/docker/docker-compose.2004.58.yaml
@@ -12,6 +12,7 @@ services:
   test:
     image: swift-log:20.04-5.8
     environment:
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -11,7 +11,6 @@ services:
   test:
     image: swift-log:22.04-5.10
     environment:
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -11,6 +11,7 @@ services:
   test:
     image: swift-log:22.04-5.10
     environment:
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -12,6 +12,7 @@ services:
   test:
     image: swift-log:22.04-5.9
     environment:
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -12,7 +12,6 @@ services:
   test:
     image: swift-log:22.04-5.9
     environment:
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,6 +11,7 @@ services:
   test:
     image: swift-log:22.04-main
     environment:
+      - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       #- SANITIZER_ARG=--sanitize=thread
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - EXPLICIT_SENDABLE_ARG=-Xswiftc -require-explicit-sendable

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -11,8 +11,10 @@ services:
   test:
     image: swift-log:22.04-main
     environment:
-      - FORCE_TEST_DISCOVERY=--enable-test-discovery
       #- SANITIZER_ARG=--sanitize=thread
+      - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
+      - EXPLICIT_SENDABLE_ARG=-Xswiftc -require-explicit-sendable
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: swift-log:22.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG}"
+    command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG}"
 
   # util
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors --enable-test-discovery $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG}"
 
   # util
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG}"
+    command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG-}"
 
   # util
 


### PR DESCRIPTION
Motivation:

This becomes a critical feature in swift 6.

Modifications:

Add Sendability annotations where required.
Factor out code protected by locks.

Result:

Compiles without warnings with Sendability checking