### PR TITLE
Remove documentation for non-existent arguments

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -347,8 +347,6 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates from. Defaults
-    ///              to the module emitting the log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#fileID`.
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
@@ -482,8 +480,6 @@ extension Logger {
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
-    ///    - source: The source this log messages originates from. Defaults
-    ///              to the module emitting the log message.
     ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
     ///            defaults to `#fileID`.
     ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as


### PR DESCRIPTION
This PR removes the documentation for methods in `Logger` that mentioned non-existent arguments.

### Motivation:

Keeping the documentation accurate and in line with the code.

### Modifications:

Removed inappropriate documentation.

### Result:

Ensured consistency between the documentation and the code.