### PR TITLE
Fix deprecation warnings around default log implementations on handlers

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1282,8 +1282,7 @@ public struct SwiftLogNoOpLogHandler: LogHandler {
                     source: String,
                     file: String,
                     function: String,
-                    line: UInt) {
-    }
+                    line: UInt) {}
 
     @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
         get {

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1276,6 +1276,15 @@ public struct SwiftLogNoOpLogHandler: LogHandler {
 
     @inlinable public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {}
 
+    public func log(level: Logger.Level,
+                    message: Logger.Message,
+                    metadata: Logger.Metadata?,
+                    source: String,
+                    file: String,
+                    function: String,
+                    line: UInt) {
+    }
+
     @inlinable public subscript(metadataKey _: String) -> Logger.Metadata.Value? {
         get {
             return nil

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -16,6 +16,7 @@
 import XCTest
 
 final class CompatibilityTest: XCTestCase {
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func testAllLogLevelsWorkWithOldSchoolLogHandlerWorks() {
         let testLogging = OldSchoolTestLogging()
 
@@ -45,6 +46,7 @@ private struct OldSchoolTestLogging {
     private let _config = Config() // shared among loggers
     private let recorder = Recorder() // shared among loggers
 
+    @available(*, deprecated, message: "Testing deprecated functionality")
     func make(label: String) -> any LogHandler {
         return OldSchoolLogHandler(label: label,
                                    config: self.config,
@@ -57,6 +59,7 @@ private struct OldSchoolTestLogging {
     var history: some History { return self.recorder }
 }
 
+@available(*, deprecated, message: "Testing deprecated functionality")
 private struct OldSchoolLogHandler: LogHandler {
     var label: String
     let config: Config


### PR DESCRIPTION
Motivation:

Latest swift introduces new warnings when deprecated default implementations are used.

Modifications:

Add new log implementation to NoopLogHandler.
Mark test of old method as deprecated to silence warning.

Result:

Warning free builds on latest swift 6 compiler.