### PR TITLE
Remove Docc plugin which is no longer required.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,6 @@ let package = Package(
     products: [
         .library(name: "Logging", targets: ["Logging"]),
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    ],
     targets: [
         .target(
             name: "Logging",


### PR DESCRIPTION
Motivation:

Plugin is no longer required to produce docs.
There are now warnings in the plugin when included and it will delay build a small amount.

Modifications:

Remove plugin dependency.

Result:

No dependencies.