### PR TITLE
Disable existential any build setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,12 @@
 import PackageDescription
 
 let swiftSettings: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
+    // TODO: re-enable this when 5.8 is no longer supported. Having this
+    // enabled propagates to consumers before 5.8 which can result in build
+    // failures if the caller is using an existential from this package without.
+    // the explicit 'any'.
+    //
+    // .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,6 @@
 
 import PackageDescription
 
-let swiftSettings: [SwiftSetting] = [
-    // TODO: re-enable this when 5.8 is no longer supported. Having this
-    // enabled propagates to consumers before 5.8 which can result in build
-    // failures if the caller is using an existential from this package without.
-    // the explicit 'any'.
-    //
-    // .enableUpcomingFeature("ExistentialAny"),
-]
-
 let package = Package(
     name: "swift-log",
     products: [
@@ -32,13 +23,11 @@ let package = Package(
     targets: [
         .target(
             name: "Logging",
-            dependencies: [],
-            swiftSettings: swiftSettings
+            dependencies: []
         ),
         .testTarget(
             name: "LoggingTests",
-            dependencies: ["Logging"],
-            swiftSettings: swiftSettings
+            dependencies: ["Logging"]
         ),
     ]
 )

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -12,6 +12,7 @@ services:
     image: swift-log:22.04-5.10
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -12,8 +12,9 @@ services:
     image: swift-log:22.04-5.10
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
       #- SANITIZER_ARG=--sanitize=thread
+      # Generated test manifest uses existentials without 'any'.
+      #- EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
 
   shell:
     image: swift-log:22.04-5.10

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,6 +13,7 @@ services:
     image: swift-log:22.04-5.9
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
+      - EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
       #- SANITIZER_ARG=--sanitize=thread
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -16,7 +16,8 @@ services:
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - EXPLICIT_SENDABLE_ARG=-Xswiftc -require-explicit-sendable
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
-      - EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
+      # Generated test manifest uses existentials without 'any'.
+      #- EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
 
   shell:
     image: swift-log:22.04-main

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -16,6 +16,7 @@ services:
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
       - EXPLICIT_SENDABLE_ARG=-Xswiftc -require-explicit-sendable
       - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
+      - EXISTENTIAL_ANY_ARG=-Xswiftc -enable-upcoming-feature -Xswiftc ExistentialAny
 
   shell:
     image: swift-log:22.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG-}"
+    command: /bin/bash -xcl "swift test $${WARN_AS_ERROR_ARG-} $${SANITIZER_ARG-} $${IMPORT_CHECK_ARG-} $${EXPLICIT_SENDABLE_ARG-} $${STRICT_CONCURRENCY_ARG-} $${EXISTENTIAL_ANY_ARG-}"
 
   # util
 


### PR DESCRIPTION
Motivation:

On 5.8, if the experiment existential any setting is enabled and a consuming package holds an existential of a type from swift-log without an explicit 'any' then the build will fail.

Modifications:

- Disable the setting

Result:

Users of 5.8 aren't broken