### PR TITLE
Fix compile warnings for Swift 6 language mode

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -399,7 +399,7 @@ class LoggingTest: XCTestCase {
                                                    "lazy": .stringConvertible(LazyMetadataBox { "rendered-at-first-use" })])
     }
 
-    private func dontEvaluateThisString(file: StaticString = #file, line: UInt = #line) -> Logger.Message {
+    private func dontEvaluateThisString(file: StaticString = #filePath, line: UInt = #line) -> Logger.Message {
         XCTFail("should not have been evaluated", file: file, line: line)
         return "should not have been evaluated"
     }

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -219,7 +219,7 @@ extension History {
                      message: String,
                      metadata: Logger.Metadata? = nil,
                      source: String? = nil,
-                     file: StaticString = #file,
+                     file: StaticString = #filePath,
                      fileID: String = #fileID,
                      line: UInt = #line) {
         let source = source ?? Logger.currentModule(fileID: "\(fileID)")
@@ -232,7 +232,7 @@ extension History {
                         message: String,
                         metadata: Logger.Metadata? = nil,
                         source: String? = nil,
-                        file: StaticString = #file,
+                        file: StaticString = #filePath,
                         fileID: String = #file,
                         line: UInt = #line) {
         let source = source ?? Logger.currentModule(fileID: "\(fileID)")


### PR DESCRIPTION
This PR addresses compile warnings that occur when enabling Swift 6 language mode.

### Motivation:

The goal is to eliminate compile-time warnings when using Swift 6 language mode.

### Modifications:

Replaced `#file` with `#filePath` in `XCTFail` calls.

### Result:

The codebase now compiles without warnings in Swift 6 language mode.