### PR TITLE
add android support

### DIFF
--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -34,6 +34,8 @@ import Darwin
 import WinSDK
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #elseif canImport(Musl)
 import Musl
 #else

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -22,6 +22,8 @@ import CRT
 #else
 import Glibc
 #endif
+#elseif canImport(Android)
+import Android
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)
@@ -1094,6 +1096,8 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
         let systemStderr = CRT.stderr
         #elseif canImport(Glibc)
         let systemStderr = Glibc.stderr!
+        #elseif canImport(Android)
+        let systemStderr = Android.stderr
         #elseif canImport(Musl)
         let systemStderr = Musl.stderr!
         #elseif canImport(WASILibc)
@@ -1112,6 +1116,8 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
         let systemStdout = CRT.stdout
         #elseif canImport(Glibc)
         let systemStdout = Glibc.stdout!
+        #elseif canImport(Android)
+        let systemStdout = Android.stdout
         #elseif canImport(Musl)
         let systemStdout = Musl.stdout!
         #elseif canImport(WASILibc)

--- a/Sources/Logging/MetadataProvider.swift
+++ b/Sources/Logging/MetadataProvider.swift
@@ -18,6 +18,8 @@ import Darwin
 import CRT
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Android)
+import Android
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)


### PR DESCRIPTION
### Motivation:

Now that swift has an Android module, we should use it in swift-log to build for android.

### Modifications:

Add `Android` imports where needed. This is specifically for Swift 6+.

### Result:

I can build swift-log for android
