### PR TITLE
Correct the link of incubation-process at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Please see [SECURITY.md](SECURITY.md) for SwiftLog's security process.
 
 ## Design
 
-This logging API was designed with the contributors to the Swift on Server community and approved by the [SSWG (Swift Server Work Group)](https://swift.org/server/) to the 'sandbox level' of the SSWG's [incubation process](https://github.com/swift-server/sswg/blob/master/process/incubation.md).
+This logging API was designed with the contributors to the Swift on Server community and approved by the [SSWG (Swift Server Work Group)](https://swift.org/server/) to the 'sandbox level' of the SSWG's [incubation process](https://www.swift.org/sswg/incubation-process.html).
 
 - [pitch](https://forums.swift.org/t/logging/16027), [discussion](https://forums.swift.org/t/discussion-server-logging-api/18834), [feedback](https://forums.swift.org/t/feedback-server-logging-api-with-revisions/19375)
 - [log levels](https://forums.swift.org/t/logging-levels-for-swifts-server-side-logging-apis-and-new-os-log-apis/20365)


### PR DESCRIPTION
### Motivation:
Correct the link of incubation-process at README.md. Currently it is showing "Not Found".

### Modifications:
+ https://github.com/swift-server/sswg/blob/master/process/incubation.md => https://www.swift.org/sswg/incubation-process.html

### Result:
Correct the link of sswg-security