### PR TITLE
Add Scout to the list of available backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can choose from one of the following backends to consume your logs. If you a
 | [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack) | a fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS, which includes a logging backend for swift-log. |
 | [rwbutler/swift-log-ecs](https://github.com/rwbutler/swift-log-ecs) | a logging backend for logging in [ECS Log format](https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html). Compatible with [Vapor](https://github.com/vapor/vapor) and allows chaining of multiple LogHandlers. |
 | [ShipBook/swift-log-**shipbook**](https://github.com/ShipBook/swift-log-shipbook) | a logging backend that sends log entries to [Shipbook](https://www.shipbook.io) - Shipbook gives you the power to remotely gather, search and analyze your user logs and exceptions in the cloud, on a per-user & session basis. |
+| [Scout](https://github.com/kasianov-mikhail/scout) | CloudKit as a log storage |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can choose from one of the following backends to consume your logs. If you a
 | [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack) | a fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS, which includes a logging backend for swift-log. |
 | [rwbutler/swift-log-ecs](https://github.com/rwbutler/swift-log-ecs) | a logging backend for logging in [ECS Log format](https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html). Compatible with [Vapor](https://github.com/vapor/vapor) and allows chaining of multiple LogHandlers. |
 | [ShipBook/swift-log-**shipbook**](https://github.com/ShipBook/swift-log-shipbook) | a logging backend that sends log entries to [Shipbook](https://www.shipbook.io) - Shipbook gives you the power to remotely gather, search and analyze your user logs and exceptions in the cloud, on a per-user & session basis. |
-| [Scout](https://github.com/kasianov-mikhail/scout) | CloudKit as a log storage |
+| [kasianov-mikhail/scout](https://github.com/kasianov-mikhail/scout) | CloudKit as a log storage |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
CloudKit-based log integration  

### Motivation:

Using native backend for storing log data

### Modifications:

Add Scout to the list of available backends

### Result:

Another one option to use the package with