### PR TITLE
Remove inaccurate code comment

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1242,7 +1242,6 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
     }
 
     /// Flush the underlying stream.
-    /// This has no effect when using the `.always` flush mode, which is the default
     internal func flush() {
         _ = fflush(self.file)
     }


### PR DESCRIPTION
Remove an inaccurate comment from the code.

### Motivation:

The removed comment incorrectly described the `flush()` method as not having an effect when the flush mode is set to `.always`. Not only is this the opposite of the actual behavior, in fact the method itself is not affected by the flush mode at all; that check is made elsewhere. Further, at the point where the check is made, the behavior is clearly spelled out by the code making the check, so moving the comment there seems redundant. As such, it seemed best to simply remove it altogether.

### Modifications:

Removed a comment.

### Result:

The inaccurate comment can no longer cause confusion.
