### PR TITLE
Add SumoLogHandler to the list of available backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can choose from one of the following backends to consume your logs. If you a
 | [kasianov-mikhail/scout](https://github.com/kasianov-mikhail/scout) | CloudKit as a log storage |
 | [PADL/AndroidLogging](https://github.com/PADL/AndroidLogging) | a logging backend for the Android in-kernel log buffer |
 | [xtremekforever/swift-systemd](https://github.com/xtremekforever/swift-systemd) | a logging backend for the [systemd](https://systemd.io/) journal |
+| [oldgrowth-games/SumoLogHandler](https://github.com/oldgrowth-games/SumoLogHandler) | a logging backend that sends log entries to [SumoLogic](https://www.sumologic.com) |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Add SumoLogHandler to the list of available backends

### Motivation:

A LogHandler for SumoLogic is available

### Modifications:

Updated the table in the README

### Result:

The README will have another backend LogHandler
