### PR TITLE
Android test fixes

### DIFF
--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -20,6 +20,8 @@ import XCTest
 import Darwin
 #elseif os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -20,6 +20,8 @@ import XCTest
 import Darwin
 #elseif os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #else
 import Glibc
 #endif


### PR DESCRIPTION
Add `import(Android)` for test cases that need it.

### Motivation:

Building tests fails for Android.

### Modifications:

Added `import(Android)`

### Result:

Test cases build for Android.