### PR TITLE
remove superfluous whitespace

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1396,7 +1396,7 @@ public struct StreamLogHandler: LogHandler {
 
         var stream = self.stream
         stream.write(
-            "\(self.timestamp()) \(level) \(self.label) :\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\n"
+            "\(self.timestamp()) \(level)\(self.label.isEmpty ? "" : " ")\(self.label):\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\n"
         )
     }
 

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -989,7 +989,31 @@ class LoggingTest: XCTestCase {
         log.critical("\(testString)", source: source)
 
         let pattern =
-            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\s\\[\(source)\\]\\s\(testString)$"
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label):\\s\\[\(source)\\]\\s\(testString)$"
+
+        let messageSucceeded =
+            interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(
+                of: pattern,
+                options: .regularExpression
+            ) != nil
+
+        XCTAssertTrue(messageSucceeded)
+        XCTAssertEqual(interceptStream.strings.count, 1)
+    }
+
+    func testStreamLogHandlerOutputFormatWithEmptyLabel() {
+        let interceptStream = InterceptStream()
+        LoggingSystem.bootstrapInternal { label in
+            StreamLogHandler(label: label, stream: interceptStream)
+        }
+        let source = "testSource"
+        let log = Logger(label: "")
+
+        let testString = "my message is better than yours"
+        log.critical("\(testString)", source: source)
+
+        let pattern =
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical):\\s\\[\(source)\\]\\s\(testString)$"
 
         let messageSucceeded =
             interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(
@@ -1014,7 +1038,7 @@ class LoggingTest: XCTestCase {
         log.critical("\(testString)", metadata: ["test": "test"], source: source)
 
         let pattern =
-            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label)\\s:\\stest=test\\s\\[\(source)\\]\\s\(testString)$"
+            "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\+|-)\\d{4}\\s\(Logger.Level.critical)\\s\(label):\\stest=test\\s\\[\(source)\\]\\s\(testString)$"
 
         let messageSucceeded =
             interceptStream.interceptedText?.trimmingCharacters(in: .whitespacesAndNewlines).range(


### PR DESCRIPTION
### Motivation:

`StreamLogHandler` has at some point in time acquired an extra whitespace:

```
2025-07-18T10:09:12+0100 notice label : hello
                                     ^
                                     |
                                     this one is superfluous
```

but we don't typically put spaces in front of `:`s. This PR changes it to

```
2025-07-18T10:09:12+0100 notice label: hello
                                     ^
                                     |
                                     no extra space
```

Additionally, if the label is empty (`""`), then we shouldn't print any spaces there. So with an empty label, we go from

```
2025-07-18T10:09:12+0100 notice  : hello
                               ^^
                                |
                                two superfluous spaces
```

to

```
2025-07-18T10:09:12+0100 notice: hello
                               ^
                               |
                               no extra spaces
```



### Modifications:

- Remove superfluous space if label is not empty
- Remove two superfluous spaces if label is empty

### Result:

- Somewhat more compact output
- Nicer output