### PR TITLE
Append `.git` for Importing Dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import PackageDescription
 let package = Package(
     name: "YourApp",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log", from: "1.6.0")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
As `Importing Dependencies` Guide at https://www.swift.org/documentation/package-manager/ .I would like to append `.git` for the link. It is minor but I think we should consistent (append .git) with https://www.swift.org/documentation/package-manager/ .

### Modifications:
+ Readme.md

### Result:
Consistent `Importing Dependencies` with https://www.swift.org/documentation/package-manager/
