### PR TITLE
Enable release mode builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,8 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      windows_6_0_enabled: true
+      windows_6_1_enabled: true
+      windows_nightly_next_enabled: true
+      windows_nightly_main_enabled: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,7 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-log
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,3 +45,7 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-log
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,3 +49,8 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      windows_6_0_enabled: true
+      windows_6_1_enabled: true
+      windows_nightly_next_enabled: true
+      windows_nightly_main_enabled: true


### PR DESCRIPTION
### Motivation:

Some errors do not show up in debug builds. Enabling release mode builds improves the CI coverage.

### Modifications:

Enable release mode builds for pull requests and scheduled builds on main.

### Result:

Improved CI coverage.