### PR TITLE
Add Wasm builds to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,3 +54,11 @@ jobs:
       windows_6_1_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
+
+  wasm:
+    name: Wasm Swift SDK
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false


### PR DESCRIPTION
`swift-log` should be built for Wasm as one of the officially supported platforms on CI to prevent possible future regressions.