### PR TITLE
Erase file pointer types for default log handler on Android 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,9 @@ let package = Package(
     targets: [
         .target(
             name: "Logging",
-            dependencies: []
+            dependencies: ["CSwiftLogAndroidSupport"]
         ),
+        .target(name: "CSwiftLogAndroidSupport"),
         .testTarget(
             name: "LoggingTests",
             dependencies: ["Logging"]

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     targets: [
         .target(
             name: "Logging",
-            dependencies: ["CSwiftLogAndroidSupport"]
+            dependencies: [.byName(name: "CSwiftLogAndroidSupport", condition: .when(platforms: [.android]))]
         ),
         .target(name: "CSwiftLogAndroidSupport"),
         .testTarget(

--- a/Sources/CSwiftLogAndroidSupport/include/CSwiftLogAndroidSupport.h
+++ b/Sources/CSwiftLogAndroidSupport/include/CSwiftLogAndroidSupport.h
@@ -6,7 +6,6 @@
 // These C functions will be called from Swift. They provide a stable
 // interface, hiding the pointer type differences between Android versions.
 
-// Get opaque pointers to standard streams.
 void *shim_stdout(void);
 void *shim_stderr(void);
 

--- a/Sources/CSwiftLogAndroidSupport/include/CSwiftLogAndroidSupport.h
+++ b/Sources/CSwiftLogAndroidSupport/include/CSwiftLogAndroidSupport.h
@@ -1,0 +1,18 @@
+#ifndef SWIFT_LOG_ANDROID_SUPPORT_H
+#define SWIFT_LOG_ANDROID_SUPPORT_H
+
+#include <stdio.h>
+
+// These C functions will be called from Swift. They provide a stable
+// interface, hiding the pointer type differences between Android versions.
+
+// Get opaque pointers to standard streams.
+void *shim_stdout(void);
+void *shim_stderr(void);
+
+void shim_flockfile(void *file);
+void shim_funlockfile(void *file);
+size_t shim_fwrite(const void *ptr, size_t size, size_t count, void *file);
+int shim_fflush(void *file);
+
+#endif // SWIFT_LOG_ANDROID_SUPPORT_H

--- a/Sources/CSwiftLogAndroidSupport/include/shim.c
+++ b/Sources/CSwiftLogAndroidSupport/include/shim.c
@@ -1,0 +1,25 @@
+#include "CSwiftLogAndroidSupport.h"
+
+void *shim_stdout(void) {
+    return stdout;
+}
+
+void *shim_stderr(void) {
+    return stderr;
+}
+
+void shim_flockfile(void *file) {
+    flockfile(file);
+}
+
+void shim_funlockfile(void *file) {
+    funlockfile(file);
+}
+
+size_t shim_fwrite(const void *ptr, size_t size, size_t count, void *file) {
+    return fwrite(ptr, size, count, file);
+}
+
+int shim_fflush(void *file) {
+    return fflush(file);
+}

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -630,7 +630,13 @@ extension Logger {
 /// implementation.
 public enum LoggingSystem {
     private static let _factory = FactoryBox(
-        { label, _ in StreamLogHandler.standardError(label: label) },
+        { label, _ in
+            #if !os(Android)
+            StreamLogHandler.standardError(label: label)
+            #else
+            SwiftLogNoOpLogHandler()
+            #endif
+        },
         violationErrorMesage: "logging system can only be initialized once per process."
     )
     private static let _metadataProviderFactory = MetadataProviderBox(
@@ -1203,7 +1209,9 @@ public struct MultiplexLogHandler: LogHandler {
     }
 }
 
-#if canImport(WASILibc) || os(Android)
+#if !os(Android)
+
+#if canImport(WASILibc)
 internal typealias CFilePointer = OpaquePointer
 #else
 internal typealias CFilePointer = UnsafeMutablePointer<FILE>
@@ -1457,6 +1465,8 @@ public struct StreamLogHandler: LogHandler {
         }
     }
 }
+
+#endif
 
 /// No operation LogHandler, used when no logging is required
 public struct SwiftLogNoOpLogHandler: LogHandler {

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -24,6 +24,7 @@ import Glibc
 #endif
 #elseif canImport(Android)
 import Android
+import CSwiftLogAndroidSupport
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)
@@ -630,13 +631,7 @@ extension Logger {
 /// implementation.
 public enum LoggingSystem {
     private static let _factory = FactoryBox(
-        { label, _ in
-            #if !os(Android)
-            StreamLogHandler.standardError(label: label)
-            #else
-            SwiftLogNoOpLogHandler()
-            #endif
-        },
+        { label, _ in StreamLogHandler.standardError(label: label) },
         violationErrorMesage: "logging system can only be initialized once per process."
     )
     private static let _metadataProviderFactory = MetadataProviderBox(
@@ -1209,10 +1204,10 @@ public struct MultiplexLogHandler: LogHandler {
     }
 }
 
-#if !os(Android)
-
 #if canImport(WASILibc)
 internal typealias CFilePointer = OpaquePointer
+#elseif canImport(Android)
+internal typealias CFilePointer = UnsafeMutableRawPointer
 #else
 internal typealias CFilePointer = UnsafeMutablePointer<FILE>
 #endif
@@ -1230,6 +1225,8 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
             _lock_file(self.file)
             #elseif canImport(WASILibc)
             // no file locking on WASI
+            #elseif canImport(Android)
+            shim_flockfile(self.file)
             #else
             flockfile(self.file)
             #endif
@@ -1238,11 +1235,17 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
                 _unlock_file(self.file)
                 #elseif canImport(WASILibc)
                 // no file locking on WASI
+                #elseif canImport(Android)
+                shim_funlockfile(self.file)
                 #else
                 funlockfile(self.file)
                 #endif
             }
+            #if canImport(Android)
+            _ = shim_fwrite(utf8Bytes.baseAddress!, 1, utf8Bytes.count, self.file)
+            #else
             _ = fwrite(utf8Bytes.baseAddress!, 1, utf8Bytes.count, self.file)
+            #endif
             if case .always = self.flushMode {
                 self.flush()
             }
@@ -1251,7 +1254,11 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
 
     /// Flush the underlying stream.
     internal func flush() {
+        #if canImport(Android)
+        _ = shim_fflush(self.file)
+        #else
         _ = fflush(self.file)
+        #endif
     }
 
     internal func contiguousUTF8(_ string: String) -> String.UTF8View {
@@ -1269,7 +1276,7 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
         #elseif canImport(Glibc)
         let systemStderr = Glibc.stderr!
         #elseif canImport(Android)
-        let systemStderr = Android.stderr
+        let systemStderr = shim_stderr()!
         #elseif canImport(Musl)
         let systemStderr = Musl.stderr!
         #elseif canImport(WASILibc)
@@ -1289,7 +1296,7 @@ internal struct StdioOutputStream: TextOutputStream, @unchecked Sendable {
         #elseif canImport(Glibc)
         let systemStdout = Glibc.stdout!
         #elseif canImport(Android)
-        let systemStdout = Android.stdout
+        let systemStdout = shim_stdout()!
         #elseif canImport(Musl)
         let systemStdout = Musl.stdout!
         #elseif canImport(WASILibc)
@@ -1465,8 +1472,6 @@ public struct StreamLogHandler: LogHandler {
         }
     }
 }
-
-#endif
 
 /// No operation LogHandler, used when no logging is required
 public struct SwiftLogNoOpLogHandler: LogHandler {


### PR DESCRIPTION
Introduces a C shim to erase the pointer type of stdio types, that are different across Android versions.

With this addition `swift-log` and any packages that use it can be compiled on Android 23+

Resolves #374 