### PR TITLE
Add option to pass Errors to log functions

### DIFF
--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -139,6 +139,20 @@ public protocol LogHandler: _SwiftLogSendableLogHandler {
     func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    )
+    
+    /// SwiftLog 1.6 compatibility method. Please do _not_ implement, implement
+    /// `log(level:message:error:metadata:source:file:function:line:)` instead.
+    @available(*, deprecated, renamed: "log(level:message:error:metadata:source:file:function:line:)")
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
         metadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -147,8 +161,8 @@ public protocol LogHandler: _SwiftLogSendableLogHandler {
     )
 
     /// SwiftLog 1.0 compatibility method. Please do _not_ implement, implement
-    /// `log(level:message:metadata:source:file:function:line:)` instead.
-    @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
+    /// `log(level:message:error:metadata:source:file:function:line:)` instead.
+    @available(*, deprecated, renamed: "log(level:message:error:metadata:source:file:function:line:)")
     func log(
         level: Logging.Logger.Level,
         message: Logging.Logger.Message,
@@ -196,6 +210,7 @@ extension LogHandler {
                     level: .warning,
                     message:
                         "Attempted to set metadataProvider on \(Self.self) that did not implement support for them. Please contact the log handler maintainer to implement metadata provider support.",
+                    error: nil,
                     metadata: nil,
                     source: "Logging",
                     file: #file,
@@ -213,6 +228,20 @@ extension LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        self.log(level: level, message: message, metadata: metadata, source: source, file: file, function: function, line: line)
+    }
+    
+    @available(*, deprecated, renamed: "log(level:message:error:metadata:source:file:function:line:)")
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
         metadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -222,7 +251,7 @@ extension LogHandler {
         self.log(level: level, message: message, metadata: metadata, file: file, function: function, line: line)
     }
 
-    @available(*, deprecated, renamed: "log(level:message:metadata:source:file:function:line:)")
+    @available(*, deprecated, renamed: "log(level:message:error:metadata:source:file:function:line:)")
     public func log(
         level: Logging.Logger.Level,
         message: Logging.Logger.Message,
@@ -234,6 +263,7 @@ extension LogHandler {
         self.log(
             level: level,
             message: message,
+            error: nil,
             metadata: metadata,
             source: Logger.currentModule(filePath: file),
             file: file,

--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -104,6 +104,49 @@ extension Logger {
     /// - parameters:
     ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func log(
+        level: Logger.Level,
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        if self.logLevel <= level {
+            self.handler.log(
+                level: level,
+                message: message(),
+                error: error,
+                metadata: metadata(),
+                source: source() ?? Logger.currentModule(fileID: (file)),
+                file: file,
+                function: function,
+                line: line
+            )
+        }
+    }
+    
+    /// Log a message passing the log level as a parameter.
+    ///
+    /// If the `logLevel` passed to this method is more severe than the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - level: The log level to log `message` at. For the available log levels, see `Logger.Level`.
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - source: The source this log messages originates from. Defaults
     ///              to the module emitting the log message.
@@ -123,17 +166,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        if self.logLevel <= level {
-            self.handler.log(
-                level: level,
-                message: message(),
-                metadata: metadata(),
-                source: source() ?? Logger.currentModule(fileID: (file)),
-                file: file,
-                function: function,
-                line: line
-            )
-        }
+        self.log(level: level, message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing the log level as a parameter.
@@ -214,6 +247,7 @@ extension Logger {
     @inlinable
     public func trace(
         _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
         metadata: @autoclosure () -> Logger.Metadata? = nil,
         source: @autoclosure () -> String? = nil,
         file: String = #fileID,
@@ -223,12 +257,41 @@ extension Logger {
         self.log(
             level: .trace,
             message(),
+            error: error,
             metadata: metadata(),
             source: source(),
             file: file,
             function: function,
             line: line
         )
+    }
+    
+    /// Log a message passing with the ``Logger/Level/trace`` log level.
+    ///
+    /// If `.trace` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - metadata: One-off metadata to attach to this log message
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func trace(
+        _ message: @autoclosure () -> Logger.Message,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.trace(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/trace`` log level.
@@ -263,6 +326,45 @@ extension Logger {
     ///
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func debug(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .debug,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+    
+    /// Log a message passing with the ``Logger/Level/debug`` log level.
+    ///
+    /// If `.debug` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - source: The source this log messages originates from. Defaults
     ///              to the module emitting the log message.
@@ -281,15 +383,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .debug,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.debug(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/debug`` log level.
@@ -324,6 +418,45 @@ extension Logger {
     ///
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func info(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .info,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+    
+    /// Log a message passing with the ``Logger/Level/info`` log level.
+    ///
+    /// If `.info` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - source: The source this log messages originates from. Defaults
     ///              to the module emitting the log message.
@@ -342,15 +475,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .info,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.info(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/info`` log level.
@@ -385,6 +510,45 @@ extension Logger {
     ///
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func notice(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .notice,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+    
+    /// Log a message passing with the ``Logger/Level/notice`` log level.
+    ///
+    /// If `.notice` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - source: The source this log messages originates from. Defaults
     ///              to the module emitting the log message.
@@ -403,15 +567,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .notice,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.notice(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/notice`` log level.
@@ -446,6 +602,45 @@ extension Logger {
     ///
     /// - parameters:
     ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func warning(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .warning,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+    
+    /// Log a message passing with the ``Logger/Level/warning`` log level.
+    ///
+    /// If `.warning` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
     ///    - metadata: One-off metadata to attach to this log message.
     ///    - source: The source this log messages originates from. Defaults
     ///              to the module emitting the log message.
@@ -464,15 +659,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .warning,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.warning(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/warning`` log level.
@@ -499,6 +686,45 @@ extension Logger {
     ) {
         self.warning(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
+    
+    /// Log a message passing with the ``Logger/Level/error`` log level.
+    ///
+    /// If `.error` is at least as severe as the `Logger`'s ``logLevel``, it will be logged,
+    /// otherwise nothing will happen.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func error(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .error,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
 
     /// Log a message passing with the ``Logger/Level/error`` log level.
     ///
@@ -525,15 +751,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .error,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.error(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/error`` log level.
@@ -558,9 +776,47 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.error(message(), metadata: metadata(), source: nil, file: file, function: function, line: line)
+        self.error(message(), error: nil, metadata: metadata(), source: nil, file: file, function: function, line: line)
     }
 
+    /// Log a message passing with the ``Logger/Level/critical`` log level.
+    ///
+    /// `.critical` messages will always be logged.
+    ///
+    /// - parameters:
+    ///    - message: The message to be logged. `message` can be used with any string interpolation literal.
+    ///    - error: An `Error` related to the event.
+    ///    - metadata: One-off metadata to attach to this log message.
+    ///    - source: The source this log messages originates from. Defaults
+    ///              to the module emitting the log message.
+    ///    - file: The file this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#fileID`).
+    ///    - function: The function this log message originates from (there's usually no need to pass it explicitly as
+    ///                it defaults to `#function`).
+    ///    - line: The line this log message originates from (there's usually no need to pass it explicitly as it
+    ///            defaults to `#line`).
+    @inlinable
+    public func critical(
+        _ message: @autoclosure () -> Logger.Message,
+        error: Error? = nil,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        source: @autoclosure () -> String? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: .critical,
+            message(),
+            error: error,
+            metadata: metadata(),
+            source: source(),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+    
     /// Log a message passing with the ``Logger/Level/critical`` log level.
     ///
     /// `.critical` messages will always be logged.
@@ -585,15 +841,7 @@ extension Logger {
         function: String = #function,
         line: UInt = #line
     ) {
-        self.log(
-            level: .critical,
-            message(),
-            metadata: metadata(),
-            source: source(),
-            file: file,
-            function: function,
-            line: line
-        )
+        self.critical(message(), error: nil, metadata: metadata(), source: source(), file: file, function: function, line: line)
     }
 
     /// Log a message passing with the ``Logger/Level/critical`` log level.
@@ -1133,6 +1381,7 @@ public struct MultiplexLogHandler: LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
         metadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -1143,6 +1392,7 @@ public struct MultiplexLogHandler: LogHandler {
             handler.log(
                 level: level,
                 message: message,
+                error: error,
                 metadata: metadata,
                 source: source,
                 file: file,
@@ -1371,6 +1621,7 @@ public struct StreamLogHandler: LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
         metadata explicitMetadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -1392,7 +1643,7 @@ public struct StreamLogHandler: LogHandler {
 
         var stream = self.stream
         stream.write(
-            "\(self.timestamp()) \(level)\(self.label.isEmpty ? "" : " ")\(self.label):\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\n"
+            "\(self.timestamp()) \(level)\(self.label.isEmpty ? "" : " ")\(self.label):\(prettyMetadata.map { " \($0)" } ?? "") [\(source)] \(message)\(error != nil ? " - \(error!)" : "")\n"
         )
     }
 
@@ -1472,6 +1723,17 @@ public struct SwiftLogNoOpLogHandler: LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {}
+    
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        error: Error?,
         metadata: Logger.Metadata?,
         source: String,
         file: String,

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -18,10 +18,10 @@ import Testing
 
 struct CompatibilityTest {
     @available(*, deprecated, message: "Testing deprecated functionality")
-    @Test func allLogLevelsWorkWithOldSchoolLogHandlerWorks() {
-        let testLogging = OldSchoolTestLogging()
+    @Test func allLogLevelsWorkWithPreSourceLogHandler() {
+        let testLogging = DeprecatedTestLogging()
 
-        var logger = Logger(label: "\(#function)", factory: { testLogging.make(label: $0) })
+        var logger = Logger(label: "\(#function)", factory: { testLogging.makePreSource(label: $0) })
         logger.logLevel = .trace
 
         logger.trace("yes: trace")
@@ -29,10 +29,10 @@ struct CompatibilityTest {
         logger.info("yes: info")
         logger.notice("yes: notice")
         logger.warning("yes: warning")
-        logger.error("yes: error")
+        logger.error("yes: error", error: TestError.error)
         logger.critical("yes: critical", source: "any also with some new argument that isn't propagated")
 
-        // Please note that the source is _not_ propagated (because the backend doesn't support it).
+        // Please note that the source and error are _not_ propagated (because the backend doesn't support it).
         testLogging.history.assertExist(level: .trace, message: "yes: trace", source: "no source")
         testLogging.history.assertExist(level: .debug, message: "yes: debug", source: "no source")
         testLogging.history.assertExist(level: .info, message: "yes: info", source: "no source")
@@ -41,15 +41,51 @@ struct CompatibilityTest {
         testLogging.history.assertExist(level: .error, message: "yes: error", source: "no source")
         testLogging.history.assertExist(level: .critical, message: "yes: critical", source: "no source")
     }
+    
+    @available(*, deprecated, message: "Testing deprecated functionality")
+    @Test func allLogLevelsWorkWithPreErrorLogHandler() {
+        let testLogging = DeprecatedTestLogging()
+
+        var logger = Logger(label: "\(#function)", factory: { testLogging.makePreError(label: $0) })
+        logger.logLevel = .trace
+
+        logger.trace("yes: trace")
+        logger.debug("yes: debug")
+        logger.info("yes: info")
+        logger.notice("yes: notice")
+        logger.warning("yes: warning")
+        logger.error("yes: error", error: TestError.error)
+        logger.critical("yes: critical")
+
+        // Please note that the error is _not_ propagated (because the backend doesn't support it).
+        testLogging.history.assertExist(level: .trace, message: "yes: trace")
+        testLogging.history.assertExist(level: .debug, message: "yes: debug")
+        testLogging.history.assertExist(level: .info, message: "yes: info")
+        testLogging.history.assertExist(level: .notice, message: "yes: notice")
+        testLogging.history.assertExist(level: .warning, message: "yes: warning")
+        testLogging.history.assertExist(level: .error, message: "yes: error")
+        testLogging.history.assertExist(level: .critical, message: "yes: critical")
+    }
 }
 
-private struct OldSchoolTestLogging {
+private struct DeprecatedTestLogging {
     private let _config = Config()  // shared among loggers
     private let recorder = Recorder()  // shared among loggers
-
+    
     @available(*, deprecated, message: "Testing deprecated functionality")
-    func make(label: String) -> any LogHandler {
-        OldSchoolLogHandler(
+    func makePreSource(label: String) -> any LogHandler {
+        PreSourceLogHandler(
+            label: label,
+            config: self.config,
+            recorder: self.recorder,
+            metadata: [:],
+            logLevel: .info
+        )
+    }
+    
+    @available(*, deprecated, message: "Testing deprecated functionality")
+    func makePreError(label: String) -> any LogHandler {
+        PreErrorLogHandler(
             label: label,
             config: self.config,
             recorder: self.recorder,
@@ -63,7 +99,7 @@ private struct OldSchoolTestLogging {
 }
 
 @available(*, deprecated, message: "Testing deprecated functionality")
-private struct OldSchoolLogHandler: LogHandler {
+private struct PreSourceLogHandler: LogHandler {
     var label: String
     let config: Config
     let recorder: Recorder
@@ -80,7 +116,43 @@ private struct OldSchoolLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
-        self.recorder.record(level: level, metadata: metadata, message: message, source: "no source")
+        self.recorder.record(level: level, metadata: metadata, message: message, error: nil, source: "no source")
+    }
+
+    subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+        get {
+            self.metadata[metadataKey]
+        }
+        set {
+            self.metadata[metadataKey] = newValue
+        }
+    }
+
+    var metadata: Logger.Metadata
+
+    var logLevel: Logger.Level
+}
+
+@available(*, deprecated, message: "Testing deprecated functionality")
+private struct PreErrorLogHandler: LogHandler {
+    var label: String
+    let config: Config
+    let recorder: Recorder
+
+    func make(label: String) -> some LogHandler {
+        TestLogHandler(label: label, config: self.config, recorder: self.recorder)
+    }
+
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        self.recorder.record(level: level, metadata: metadata, message: message, error: nil, source: source)
     }
 
     subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -96,6 +96,7 @@ public struct LogHandlerThatDidNotImplementMetadataProviders: LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
         metadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -105,6 +106,7 @@ public struct LogHandlerThatDidNotImplementMetadataProviders: LogHandler {
         self.testLogging.make(label: "fake").log(
             level: level,
             message: message,
+            error: error,
             metadata: metadata,
             source: source,
             file: file,
@@ -138,6 +140,7 @@ public struct LogHandlerThatDidImplementMetadataProviders: LogHandler {
     public func log(
         level: Logger.Level,
         message: Logger.Message,
+        error: Error?,
         metadata: Logger.Metadata?,
         source: String,
         file: String,
@@ -147,6 +150,7 @@ public struct LogHandlerThatDidImplementMetadataProviders: LogHandler {
         self.testLogging.make(label: "fake").log(
             level: level,
             message: message,
+            error: error,
             metadata: metadata,
             source: source,
             file: file,


### PR DESCRIPTION
Add option to pass Errors to log functions

### Motivation:

Addresses #291

### Modifications:

Add new API to Logger, that allows the caller to pass an Error object to any log function. Extend LogHandler to allow an implementation to access the error, in order to format the log appropriately. Provide default implementations to preserve backwards compatibility.

### Result:

By providing default implementations, the change should be compatible between old and new code, both from the API and implementation side. I.e. a client can use the new API and it will still work with 'old' implementations, and vice versa.