### PR TITLE
Move pre-process proposal to the proposals folder

### DIFF
--- a/Sources/Logging/Docs.docc/Proposals/SLG-0001-metadata-providers.md
+++ b/Sources/Logging/Docs.docc/Proposals/SLG-0001-metadata-providers.md
@@ -1,10 +1,10 @@
 # Metadata Providers
 
-Authors: [Moritz Lang](https://github.com/slashmo), [Konrad 'ktoso' Malawski](https://github.com/ktoso)
-
-## Introduction
-
 While global metadata attributes may be manually set on a `LogHandler` level, there's currently no way of reliably providing contextual, automatically propagated, metadata when logging with swift-log.
+
+## Authors
+
+[Moritz Lang](https://github.com/slashmo), [Konrad 'ktoso' Malawski](https://github.com/ktoso)
 
 ## Motivation
 


### PR DESCRIPTION
Move single pre-process proposal file to the new location.

### Motivation:

To have all the proposals in one place.

### Modifications:

One .md file moved.

### Result:

All proposals are in one place.
