### PR TITLE
Conform `Logger.Level` to `CustomStringConvertible` and `LosslessStringConvertible`

### DIFF
--- a/Sources/Logging/Logging.swift
+++ b/Sources/Logging/Logging.swift
@@ -1026,6 +1026,19 @@ extension Logger.Level: Comparable {
     }
 }
 
+extension Logger.Level: CustomStringConvertible, LosslessStringConvertible {
+    /// A textual representation of the log level.
+    public var description: String {
+        self.rawValue
+    }
+
+    /// Creates a log level from its textual representation.
+    /// - Parameter description: A textual representation of the log level, case insensitive.
+    public init?(_ description: String) {
+        self.init(rawValue: description.lowercased())
+    }
+}
+
 // Extension has to be done on explicit type rather than Logger.Metadata.Value as workaround for
 // https://bugs.swift.org/browse/SR-9687
 // Then we could write it as follows and it would work under Swift 5 and not only 4 as it does currently:

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -957,6 +957,11 @@ struct LoggingTest {
         #expect(Logger.Level.error < Logger.Level.critical)
     }
 
+    @Test(arguments: Logger.Level.allCases) func logLevelDescription(level: Logger.Level) {
+        #expect(level.description == level.rawValue)
+        #expect(Logger.Level(level.rawValue.uppercased()) == level)
+    }
+
     final class InterceptStream: TextOutputStream {
         var interceptedText: String?
         var strings = [String]()


### PR DESCRIPTION
Conform `Logger.Level` to `CustomStringConvertible` and `LosslessStringConvertible`.

### Motivation:

There are libraries, such as Vapor, that add these conformances privately and `@retroactive`ly. This would avoid having to implement these conformances manually in each library and would unify and standardise the implementation.

### Modifications:

Make `Logger.Level` conform to `CustomStringConvertible` and `LosslessStringConvertible`, adding a public `description` computed property that returns the `rawValue` and a public initializer that takes a `description` string, lowercases it, and passes it to the `rawValue` initializer.

### Result:

`Logger.Level` conforms to `CustomStringConvertible` and `LosslessStringConvertible`.