### PR TITLE
Reinstate InMemoryLogging product in Swift 6.0 manifest

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -18,16 +18,25 @@ import PackageDescription
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"])
+        .library(name: "Logging", targets: ["Logging"]),
+        .library(name: "InMemoryLogging", targets: ["InMemoryLogging"]),
     ],
     targets: [
         .target(
             name: "Logging",
             dependencies: []
         ),
+        .target(
+            name: "InMemoryLogging",
+            dependencies: ["Logging"]
+        ),
         .testTarget(
             name: "LoggingTests",
             dependencies: ["Logging"]
+        ),
+        .testTarget(
+            name: "InMemoryLoggingTests",
+            dependencies: ["InMemoryLogging", "Logging"]
         ),
     ]
 )


### PR DESCRIPTION
### Motivation:

In the latest release (1.9.0) the package manifest was split for Swift 6.0 and 6.1+. The 6.0 manifest lost the `InMemoryLogging` library product, causing API breakage for adopters using Swift 6.0:

```diff
% diff -u <(git show 1.8.0:Package.swift) <(git show 1.9.0:Package@swift-6.0.swift)
--- /dev/fd/63  2026-01-19 10:30:21
+++ /dev/fd/62  2026-01-19 10:30:21
@@ -18,25 +18,16 @@
 let package = Package(
     name: "swift-log",
     products: [
-        .library(name: "Logging", targets: ["Logging"]),
-        .library(name: "InMemoryLogging", targets: ["InMemoryLogging"]),
+        .library(name: "Logging", targets: ["Logging"])
     ],
     targets: [
         .target(
             name: "Logging",
             dependencies: []
         ),
-        .target(
-            name: "InMemoryLogging",
-            dependencies: ["Logging"]
-        ),
         .testTarget(
             name: "LoggingTests",
             dependencies: ["Logging"]
-        ),
-        .testTarget(
-            name: "InMemoryLoggingTests",
-            dependencies: ["InMemoryLogging", "Logging"]
         ),
     ]
 )

```

### Modifications:

Reinstate InMemoryLogging product in Swift 6.0 manifest

### Result:

Adopters using `InMemoryLogging` on Swift 6.0 are unbroken.

### Related issues:

Fixes #402 