### PR TITLE
Update benchmarks expectations on Tahoe

### DIFF
--- a/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.notice_log_with_notice_log_level.p90.json
+++ b/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.notice_log_with_notice_log_level.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 589,
+  "instructions" : 619,
   "objectAllocCount" : 0
 }

--- a/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.notice_log_with_notice_log_level_generic.p90.json
+++ b/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.notice_log_with_notice_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 589,
+  "instructions" : 619,
   "objectAllocCount" : 0
 }

--- a/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.warning_log_with_warning_log_level.p90.json
+++ b/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.warning_log_with_warning_log_level.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 3009,
+  "instructions" : 2749,
   "objectAllocCount" : 1
 }

--- a/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.warning_log_with_warning_log_level_generic.p90.json
+++ b/Benchmarks/MaxLogLevelWarning/Thresholds/Xcode 26.1/MaxLogLevelWarning.warning_log_with_warning_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 3009,
+  "instructions" : 2749,
   "objectAllocCount" : 1
 }

--- a/Benchmarks/NoTraits/Thresholds/Xcode 16.4/NoTraits.debug_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode 16.4/NoTraits.debug_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 937,
+  "instructions" : 983,
   "objectAllocCount" : 0
 }

--- a/Benchmarks/NoTraits/Thresholds/Xcode 16.4/NoTraits.error_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode 16.4/NoTraits.error_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 1718,
+  "instructions" : 1772,
   "objectAllocCount" : 0
 }

--- a/Benchmarks/NoTraits/Thresholds/Xcode 26.1/NoTraits.debug_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode 26.1/NoTraits.debug_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 855,
+  "instructions" : 895,
   "objectAllocCount" : 0
 }

--- a/Benchmarks/NoTraits/Thresholds/Xcode 26.1/NoTraits.error_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode 26.1/NoTraits.error_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,4 @@
 {
-  "instructions" : 1636,
+  "instructions" : 1684,
   "objectAllocCount" : 0
 }


### PR DESCRIPTION
Update macOS benchmarks after moving to Tahoe runners.

### Motivation:

`swift-log` has performance benchmarks measuring instructions. Results may vary from version to version of macOS.

### Modifications:

Benchmarking thresholds updated based on the Tahoe runners results.

### Result:

Benchmark jobs pass.
