### PR TITLE
Fix: Only use unsafe flag on Swift 6.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift Logging API open source project

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -57,8 +57,5 @@ where [.executable, .test, .regular].contains(
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     settings.append(.enableUpcomingFeature("InternalImportsByDefault"))
 
-    // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
-    settings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
-
     target.swiftSettings = settings
 }

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -75,8 +75,5 @@ where [.executable, .test, .regular].contains(
     // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md
     settings.append(.enableUpcomingFeature("InternalImportsByDefault"))
 
-    // https://docs.swift.org/compiler/documentation/diagnostics/nonisolated-nonsending-by-default/
-    settings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
-
     target.swiftSettings = settings
 }


### PR DESCRIPTION
### Motivation:

Package.swift needs to use tools-version 6.2, as we have dedicated 6.0 and 6.1 manifests.

Here, when building on 6.1, the Package.swift was being picked and an unsafe flag was found, which isn't allowed on 6.1 (only on 6.2+).

### Modifications:

Bump Package.swift's tools-version to 6.2.

### Result:

Should fix dependees.

