### PR TITLE
[SLG-0006]: Task-local logger proposal implementation

### DIFF
--- a/Benchmarks/NoTraits/Benchmarks/NoTraitsBenchmarks/NoTraits.swift
+++ b/Benchmarks/NoTraits/Benchmarks/NoTraitsBenchmarks/NoTraits.swift
@@ -24,4 +24,34 @@ public let benchmarks: @Sendable () -> Void = {
     makeBenchmark(loggerLevel: .error, logLevel: .debug, "_generic") { logger in
         logger.log(level: .debug, "hello, benchmarking world")
     }
+
+    // MARK: - Task-local logger benchmarks
+
+    makeBenchmark(loggerLevel: .error, logLevel: .error, "_current_read_fallback") { _ in
+        blackHole(Logger.current)
+    }
+
+    makeBenchmark(loggerLevel: .error, logLevel: .error, setScopedLogger: true, "_current_read_inside_scope") {
+        logger in
+        blackHole(Logger.current)
+    }
+
+    makeBenchmark(loggerLevel: .error, logLevel: .error, setScopedLogger: true, "_withLogger_mergingMetadata") {
+        logger in
+        withLogger(mergingMetadata: ["key": "value"]) { inner in
+            blackHole(inner)
+        }
+    }
+
+    makeBenchmark(loggerLevel: .error, logLevel: .error, setScopedLogger: true, "_withLogger_label") { logger in
+        withLogger(label: "library") { inner in
+            blackHole(inner)
+        }
+    }
+
+    makeBenchmark(loggerLevel: .error, logLevel: .error, setScopedLogger: true, "_withLogger_handler") { logger in
+        withLogger(handler: logger.handler) { inner in
+            blackHole(inner)
+        }
+    }
 }

--- a/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
+++ b/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
@@ -19,6 +19,7 @@ import Logging
 public func makeBenchmark(
     loggerLevel: Logger.Level,
     logLevel: Logger.Level,
+    setScopedLogger: Bool = false,
     _ suffix: String = "",
     _ body: @escaping (Logger) -> Void
 ) {
@@ -49,7 +50,17 @@ public func makeBenchmark(
                 ),
             ]
         )
-    ) { _ in
-        body(logger)
+    ) { benchmark in
+        if setScopedLogger {
+            withLogger(logger) { logger in
+                benchmark.startMeasurement()
+                body(logger)
+                benchmark.stopMeasurement()
+            }
+        } else {
+            benchmark.startMeasurement()
+            body(logger)
+            benchmark.stopMeasurement()
+        }
     }
 }

--- a/Sources/Logging/Docs.docc/Proposals/SLG-0006-task-local-logger.md
+++ b/Sources/Logging/Docs.docc/Proposals/SLG-0006-task-local-logger.md
@@ -1,0 +1,325 @@
+# SLG-0006: Task-local logger with automatic metadata propagation
+
+Accumulate structured logging metadata across async call stacks using task-local storage.
+
+## Overview
+
+- Proposal: SLG-0006
+- Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
+- Status: **Awaiting Review**
+- Issue: [apple/swift-log#261](https://github.com/apple/swift-log/issues/261)
+- Implementation: [apple/swift-log#414](https://github.com/apple/swift-log/pull/414)
+- Feature flag: none
+- Related links:
+  - [Lightweight proposals process description](https://github.com/apple/swift-log/blob/main/Sources/Logging/Docs.docc/Proposals/Proposals.md)
+
+### Introduction
+
+This proposal adds task-local logger storage so that metadata can accumulate across async
+call stacks without threading a `Logger` through every function signature.
+
+### Motivation
+
+**Metadata propagation requires threading a logger through every layer.** Every function on
+the path from request ingress to the bottom of the call stack has to accept, mutate, and
+forward a `Logger`:
+
+```swift
+func handleHTTPRequest(_ request: HTTPRequest, logger: Logger) async throws {
+    var logger = logger
+    logger[metadataKey: "request.id"] = "\(request.id)"
+    try await processBusinessLogic(request, logger: logger)
+}
+```
+
+**Libraries must choose between polluting their public API with a `logger:` parameter and
+losing all the caller's context.** There is no third option today.
+
+### Proposed solution
+
+Use Swift's `@TaskLocal` to propagate a logger with accumulated metadata. The caller sets up
+a scope, callees read `Logger.current` freely:
+
+```swift
+func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+    try await withLogger(mergingMetadata: ["request.id": "\(request.id)"]) { logger in
+        logger.info("Handling request")  // Has request.id automatically
+        return try await processRequest(request)  // no logger parameter needed
+    }
+}
+
+func processRequest(_ request: HTTPRequest) async throws -> User {
+    Logger.current.debug("Processing...")  // Has request.id automatically
+    DatabaseClient.query(request.sqlQuery)
+}
+```
+
+Libraries keep their APIs clean while still emitting logs with the caller's full context.
+A library that wants to log under its own label (so operators can grep by module) can
+rebrand the current logger without losing accumulated metadata:
+
+```swift
+public struct DatabaseClient {
+    public static func query(_ sql: String) async throws -> [Row] {
+        try await withLogger(label: "postgres-client", mergingMetadata: ["sql": "\(sql)"]) { logger in
+            logger.debug("Executing query")  // label = "postgres-client", metadata includes request.id and sql
+            return try await performQuery(sql)
+        }
+    }
+}
+```
+
+**Wiring it up with swift-service-lifecycle.** At the application entry point, bind the
+bootstrapped logger once; service lifecycle propagates the task-local through the
+`ServiceGroup` and into every task spawned from its `run()`:
+
+```swift
+@main
+struct MyServer {
+    static func main() async throws {
+        let logger = Logger(label: "my-server")
+        try await withLogger(logger) { _ in
+            let serviceGroup = ServiceGroup(
+                configuration: .init(
+                    services: [HTTPServer(), BackgroundWorker()],
+                    gracefulShutdownSignals: [.sigint],
+                    cancellationSignals: [.sigterm],
+                    logger: logger
+                )
+            )
+            try await serviceGroup.run()
+        }
+    }
+}
+```
+
+Metadata accumulates through nesting and task-local values propagate through structured
+concurrency (`async let`, `withTaskGroup`, child `Task {}`). `Task.detached` does not
+inherit context — capture the logger explicitly if needed.
+
+### Detailed design
+
+#### `Logger.current`
+
+Returns the logger bound by the nearest enclosing `withLogger` scope. If none has been set
+up, returns a fallback logger: the globally bootstrapped handler if
+`LoggingSystem.bootstrap` has been called, otherwise a silent `SwiftLogNoOpLogHandler`.
+
+The no-op branch returns a cached logger and emits a **one-time warning on stderr** the
+first time it is taken so a user who forgot to call `LoggingSystem.bootstrap` (or to wrap
+their entry point in `withLogger`) doesn't see logs silently disappear with no diagnostic.
+
+The bootstrapped branch invokes `LoggingSystem.factory` on every access. `Logger.current` is
+not meant to be a hot path outside of a `withLogger` scope — callers should wrap their
+entry point in `withLogger(_:_:)` and use the closure's `logger` parameter or a local `let`
+binding for repeated logging.
+
+```swift
+extension Logger {
+    /// The current task-local logger.
+    ///
+    /// Returns the logger bound by the nearest enclosing ``withLogger(_:_:)`` scope.
+    /// If none has been set up, returns a fallback logger: the globally bootstrapped
+    /// handler if ``LoggingSystem/bootstrap(_:)`` has been called, otherwise a silent
+    /// ``SwiftLogNoOpLogHandler``.
+    ///
+    /// Task-local values propagate through structured concurrency (`async let`,
+    /// `withTaskGroup`, child `Task {}`) but are **not** inherited by `Task.detached`.
+    /// Capture the logger explicitly across detached boundaries.
+    ///
+    /// For many log calls in a tight scope, prefer extracting the logger once —
+    /// either `let logger = Logger.current` or the closure's `logger` parameter
+    /// from `withLogger { logger in ... }` — instead of re-reading the task-local
+    /// on every call.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public static var current: Logger { get }
+}
+```
+
+The per-symbol `@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)` mirrors
+`@TaskLocal`'s own runtime availability. `Package.swift` intentionally does **not**
+declare a `platforms:` clause, so each symbol gates itself rather than raising the
+floor for the whole package.
+
+#### `withLogger` free functions
+
+Two overload groups, each with sync and async variants. The closure receives the logger as
+a parameter to avoid repeated task-local lookups inside the closure body.
+
+**Bind a specific logger:**
+
+```swift
+/// Runs `operation` with `logger` bound to the task-local context.
+///
+/// Code called within `operation` can read the logger via ``Logger/current`` without an
+/// explicit parameter. Binding a different logger with this overload **replaces** the
+/// current task-local logger; any metadata accumulated by an outer
+/// ``withLogger(logLevel:mergingMetadata:_:)`` scope is not carried over. Use the modifying
+/// overload to layer context instead.
+///
+/// ```swift
+/// let logger = Logger(label: "app")
+/// await withLogger(logger) { logger in
+///     logger.info("Application started")
+///     await handleRequests()  // reads Logger.current
+/// }
+/// ```
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+public func withLogger<Result>(
+    _ logger: Logger,
+    _ operation: (Logger) throws -> Result
+) rethrows -> Result
+
+/// Async variant of ``withLogger(_:_:)``. See that function for semantics.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+nonisolated(nonsending)
+public func withLogger<Result>(
+    _ logger: Logger,
+    _ operation: nonisolated(nonsending) (Logger) async throws -> Result
+) async rethrows -> Result
+```
+
+**Modify the current task-local logger:**
+
+```swift
+/// Runs `operation` with a modified copy of ``Logger/current`` bound to the task-local
+/// context. `nil` parameters leave the corresponding aspect unchanged; nested scopes
+/// accumulate metadata.
+///
+/// Unlike ``withLogger(_:_:)``, which **replaces** the task-local logger, this overload
+/// **layers on top of** the current one — metadata accumulated by enclosing scopes is
+/// preserved.
+///
+/// - `label` — rebrands the current logger with the given label while keeping the existing
+///   handler, metadata, and log level. Useful for library code that wants to emit logs
+///   under its own label (e.g. `"postgres-client"`) while still inheriting the caller's
+///   accumulated metadata.
+/// - `handler` — replaces the current logger's handler for the scope. Primarily useful in
+///   tests to route logs through an `InMemoryLogHandler` or similar, while keeping the
+///   caller's label and accumulated metadata.
+/// - `logLevel` — replaces the current log level.
+/// - `mergingMetadata` — merges into the handler's base metadata; keys present in
+///   `mergingMetadata` override existing values for the same keys.
+///
+/// With no arguments, this overload re-binds ``Logger/current`` unchanged — a convenient
+/// way to extract it into a local variable for repeated use inside the closure.
+///
+/// ```swift
+/// withLogger(mergingMetadata: ["request.id": "\(request.id)"]) { logger in
+///     logger.info("Handling request")
+///     withLogger(mergingMetadata: ["user.id": "\(user.id)"]) { logger in
+///         logger.info("Authenticated")  // sees both request.id and user.id
+///     }
+/// }
+/// ```
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+public func withLogger<Result>(
+    label: String? = nil,
+    handler: (any LogHandler)? = nil,
+    logLevel: Logger.Level? = nil,
+    mergingMetadata: Logger.Metadata? = nil,
+    _ operation: (Logger) throws -> Result
+) rethrows -> Result
+
+/// Async variant of ``withLogger(label:handler:logLevel:mergingMetadata:_:)``. See that
+/// function for semantics.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+nonisolated(nonsending)
+public func withLogger<Result>(
+    label: String? = nil,
+    handler: (any LogHandler)? = nil,
+    logLevel: Logger.Level? = nil,
+    mergingMetadata: Logger.Metadata? = nil,
+    _ operation: nonisolated(nonsending) (Logger) async throws -> Result
+) async rethrows -> Result
+```
+
+Calling `withLogger { logger in ... }` with no arguments is the single-lookup idiom for
+extracting `Logger.current` into a local variable for repeated use inside the closure —
+analogous to `withSpan { span in ... }` in `swift-distributed-tracing`.
+
+> Note: `rethrows` (not `throws(Failure)`) and the absence of a `Sendable` constraint on
+> `Result` mirror the shape of `TaskLocal.withValue` in the current standard library.
+
+#### Relationship to `MetadataProvider`
+
+Metadata merged via `withLogger(mergingMetadata:)` is written into the handler's base
+metadata on the per-task logger copy. If a handler has a `MetadataProvider` attached — for
+example a bootstrapped OpenTelemetry provider that reads `trace.id` from `ServiceContext` —
+the provider still runs at log-emission time and follows the handler's conventional merge
+order (base < provider < per-statement).
+
+This proposal does **not** add a `metadataProvider:` parameter to the modifying overload.
+Application code that wants to swap the provider for a scope should construct a new `Logger`
+and use the binding overload. Keeping the two concerns separate avoids shipping the
+replace-vs-compose question as part of the core API.
+
+### API stability
+
+**For existing `Logger` users:** no changes. The new API is purely additive.
+
+**For existing `LogHandler` implementations:** no changes required. Task-local loggers use
+the same `LogHandler` interface; no new protocol requirements are added.
+
+**Package platform minimums.** `Package.swift` intentionally does not gain a `platforms:`
+clause. Each new symbol carries `@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)`
+to match `@TaskLocal`'s runtime availability. Callers targeting older deployment versions
+keep working; they just can't call the task-local API.
+
+**ABI and resilience.** All four `withLogger` free-function overloads, `Logger.current`'s
+`@TaskLocal` storage, and the internal `withTaskLocalLogger` helpers are `@inlinable` /
+`@usableFromInline`. This is a deliberate commitment: the forwarders are thin wrappers
+around `TaskLocal.withValue`, and forcing a non-inlined call frame on every `withLogger`
+scope entry would defeat the point of a task-local-shaped API. The consequence is that
+the representation of `Logger.taskLocalLogger`, the shape of `withTaskLocalLogger`, and
+the bodies of the four overloads are frozen as of this proposal — future refactors can
+only change them in source-compatible, ABI-compatible ways. `Logger.current` itself is
+deliberately **not** `@inlinable` so the fallback policy (bootstrapped factory vs. cached
+no-op, warn-once emission) can evolve.
+
+**Source compatibility caveat.** The name `withLogger` is added at the top-level namespace.
+Codebases that previously defined their own free `withLogger` function may need to
+fully-qualify calls (`Logging.withLogger(...)`) or rename their own.
+
+### Future directions
+
+None.
+
+### Alternatives considered
+
+#### Task-local metadata dictionary instead of task-local logger
+
+Make only the metadata dictionary task-local, so ad-hoc `Logger(label:)` calls automatically
+merge it. Rejected because it changes default behavior for all existing logger creation
+(breaking semantic change) and overlaps with `swift-distributed-tracing`'s
+`ServiceContext`.
+
+#### Static methods on `Logger` instead of free functions
+
+`Logger.withCurrent(...)` instead of `withLogger(...)`. Rejected — inconsistent with
+`withSpan(...)` from `swift-distributed-tracing` and `withMetricsFactory(...)` from
+`swift-metrics`. Free functions follow the established ecosystem convention.
+
+#### Use `ServiceContext` from swift-distributed-tracing instead of a new task-local
+
+Store metadata in the existing `ServiceContext` — propagated by `swift-service-context`,
+the leaf package already designed as a shared propagation primitive — rather than
+introducing a second `@TaskLocal`. Rejected because the two propagation channels serve
+different use cases: `ServiceContext` carries *distributed* correlation (trace/span IDs,
+baggage) that flows across process boundaries, while `withLogger(mergingMetadata:)`
+accumulates *local* per-scope logger configuration (label, log level, handler, and
+application metadata like `request.id`) that is meaningful only within a single process.
+The task-local logger also carries more than metadata — it holds the `LogHandler`, log
+level, and label, none of which belong in a context intended for cross-process propagation.
+The existing `MetadataProvider` already bridges the two systems at log-emission time:
+handlers read trace/span IDs from `ServiceContext` without swift-log depending on it.
+
+#### No closure parameter — require `Logger.current` inside the closure
+
+`withLogger(logger) { ... }` without a parameter, reading `Logger.current` inside. Rejected
+because passing the logger avoids repeated task-local lookups, follows the `withSpan`
+convention, and makes it obvious at the call site which logger is in use.

--- a/Sources/Logging/Logger+With.swift
+++ b/Sources/Logging/Logger+With.swift
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension Logger {
+    /// Updates optional aspects of this logger in place.
+    ///
+    /// - `logLevel` — replaces the current log level.
+    /// - `mergingMetadata` — merges into the handler's base metadata; keys present in
+    ///   `mergingMetadata` override existing values for the same keys.
+    @usableFromInline
+    internal mutating func update(
+        logLevel: Logger.Level? = nil,
+        mergingMetadata: Logger.Metadata? = nil
+    ) {
+        if let logLevel {
+            self.logLevel = logLevel
+        }
+        if let mergingMetadata {
+            for (key, value) in mergingMetadata {
+                self[metadataKey: key] = value
+            }
+        }
+    }
+
+    /// Returns a copy of this logger rebranded with a new label, preserving the existing
+    /// handler (so base metadata, log level, and metadata provider come along).
+    @usableFromInline
+    internal func relabelled(_ newLabel: String) -> Logger {
+        Logger(label: newLabel, self.handler)
+    }
+}
+
+// MARK: - withLogger() free functions for task-local logger
+
+// Note: `rethrows` (not `throws(Failure)`) and no `Sendable` constraint on `Result` mirror
+// the shape of `TaskLocal.withValue` in the current standard library. Revisit if the
+// standard library adopts typed throws on `TaskLocal`.
+
+/// Runs `operation` with `logger` bound to the task-local context.
+///
+/// Code called within `operation` can read the logger via ``Logger/current`` without an
+/// explicit parameter. Binding a different logger with this overload **replaces** the
+/// current task-local logger; any metadata accumulated by an outer
+/// ``withLogger(label:logLevel:mergingMetadata:_:)`` scope is not carried over. Use the
+/// modifying overload to layer context instead.
+///
+/// ```swift
+/// let logger = Logger(label: "app")
+/// await withLogger(logger) { logger in
+///     logger.info("Application started")
+///     await handleRequests()  // reads Logger.current
+/// }
+/// ```
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+public func withLogger<Result>(
+    _ logger: Logger,
+    _ operation: (Logger) throws -> Result
+) rethrows -> Result {
+    try Logger.withTaskLocalLogger(logger) {
+        try operation(logger)
+    }
+}
+
+/// Async variant of ``withLogger(_:_:)``. See that function for semantics.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+nonisolated(nonsending)
+    public func withLogger<Result>(
+        _ logger: Logger,
+        _ operation: nonisolated(nonsending) (Logger) async throws -> Result
+    ) async rethrows -> Result
+{
+    try await Logger.withTaskLocalLogger(logger) {
+        try await operation(logger)
+    }
+}
+
+/// Runs `operation` with a modified copy of ``Logger/current`` bound to the task-local
+/// context. `nil` parameters leave the corresponding aspect unchanged; nested scopes
+/// accumulate metadata.
+///
+/// Unlike ``withLogger(_:_:)``, which **replaces** the task-local logger, this overload
+/// **layers on top of** the current one — metadata accumulated by enclosing scopes is
+/// preserved.
+///
+/// - `label` — rebrands the current logger with the given label while keeping the existing
+///   handler, metadata, and log level. Useful for library code that wants to emit logs
+///   under its own label (for example `"postgres-client"`) while still inheriting the
+///   caller's accumulated metadata.
+/// - `handler` — replaces the current logger's handler for the scope. Primarily useful in
+///   tests to route logs through an `InMemoryLogHandler` or similar, while keeping the
+///   caller's label and accumulated metadata.
+/// - `logLevel` — replaces the current log level.
+/// - `mergingMetadata` — merges into the handler's base metadata; keys present in
+///   `mergingMetadata` override existing values for the same keys.
+///
+/// With no arguments, this overload re-binds ``Logger/current`` unchanged — a convenient
+/// way to extract it into a local variable for repeated use inside the closure.
+///
+/// ```swift
+/// withLogger(mergingMetadata: ["request.id": "\(request.id)"]) { logger in
+///     logger.info("Handling request")
+///     withLogger(mergingMetadata: ["user.id": "\(user.id)"]) { logger in
+///         logger.info("Authenticated")  // sees both request.id and user.id
+///     }
+/// }
+/// ```
+///
+/// When no `withLogger` scope has been set up and no `LoggingSystem` bootstrap has
+/// happened, `Logger.current` (and therefore this function) returns a silent no-op
+/// fallback — a one-time warning is emitted on stderr the first time this occurs.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+public func withLogger<Result>(
+    label: String? = nil,
+    handler: (any LogHandler)? = nil,
+    logLevel: Logger.Level? = nil,
+    mergingMetadata: Logger.Metadata? = nil,
+    _ operation: (Logger) throws -> Result
+) rethrows -> Result {
+    var logger = Logger.current
+    if let handler {
+        logger.handler = handler
+    }
+    if let label {
+        logger = logger.relabelled(label)
+    }
+    logger.update(logLevel: logLevel, mergingMetadata: mergingMetadata)
+    return try Logger.withTaskLocalLogger(logger) {
+        try operation(logger)
+    }
+}
+
+/// Async variant of ``withLogger(label:handler:logLevel:mergingMetadata:_:)``. See that
+/// function for semantics.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+@inlinable
+nonisolated(nonsending)
+    public func withLogger<Result>(
+        label: String? = nil,
+        handler: (any LogHandler)? = nil,
+        logLevel: Logger.Level? = nil,
+        mergingMetadata: Logger.Metadata? = nil,
+        _ operation: nonisolated(nonsending) (Logger) async throws -> Result
+    ) async rethrows -> Result
+{
+    var logger = Logger.current
+    if let handler {
+        logger.handler = handler
+    }
+    if let label {
+        logger = logger.relabelled(label)
+    }
+    logger.update(logLevel: logLevel, mergingMetadata: mergingMetadata)
+    return try await Logger.withTaskLocalLogger(logger) {
+        try await operation(logger)
+    }
+}

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -34,7 +34,7 @@ public struct Logger {
         @usableFromInline
         var handler: any LogHandler
 
-        @inlinable
+        @usableFromInline
         init(label: String, handler: any LogHandler) {
             self.label = label
             self.handler = handler
@@ -1433,6 +1433,117 @@ extension Logger.MetadataValue: ExpressibleByArrayLiteral {
     /// - Parameter elements: A array literal of metadata values.
     public init(arrayLiteral elements: Logger.Metadata.Value...) {
         self = .array(elements)
+    }
+}
+
+// MARK: - Task-local logger storage
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Logger {
+    /// Task-local storage for implicit logger context propagation.
+    ///
+    /// Implementation detail. Use ``Logger/current`` or the `withLogger` free functions instead.
+    ///
+    /// `@usableFromInline` is a deliberate ABI commitment required by the `@inlinable`
+    /// `withLogger` forwarders — do not demote to `internal` without also removing
+    /// `@inlinable` from them.
+    @usableFromInline
+    @TaskLocal
+    static var taskLocalLogger: Logger?
+
+    /// Fallback logger used when ``current`` is read outside of any `withLogger` scope.
+    ///
+    /// If ``LoggingSystem`` has been bootstrapped, builds a logger from that factory on
+    /// every call — callers in hot paths should wrap their entry point in
+    /// ``withLogger(_:_:)`` rather than reading ``current`` directly. Otherwise returns the
+    /// cached silent ``SwiftLogNoOpLogHandler``-backed logger and emits a one-time warning
+    /// on stderr so the silent drop can be diagnosed. `StreamLogHandler.standardError` is
+    /// intentionally avoided here — it would emit per-call noise.
+    internal static func makeFallbackLogger() -> Logger {
+        if LoggingSystem.isBootstrapped {
+            return Logger(
+                label: "task-local-fallback",
+                LoggingSystem.factory("task-local-fallback", LoggingSystem.metadataProvider)
+            )
+        }
+        _noOpFallbackWarnOnce.warnOnce()
+        return _taskLocalNoOpFallback
+    }
+
+    /// Thin wrapper over `TaskLocal.withValue` so call sites don't need to reach into
+    /// the `@usableFromInline` task-local storage.
+    @usableFromInline
+    nonisolated(nonsending)
+        static func withTaskLocalLogger<Return, Failure: Error>(
+            _ value: Logger,
+            operation: nonisolated(nonsending) () async throws(Failure) -> Return
+        ) async rethrows -> Return
+    {
+        try await Self.$taskLocalLogger.withValue(value, operation: operation)
+    }
+
+    @usableFromInline
+    static func withTaskLocalLogger<Return, Failure: Error>(
+        _ value: Logger,
+        operation: () throws(Failure) -> Return
+    ) rethrows -> Return {
+        try Self.$taskLocalLogger.withValue(value, operation: operation)
+    }
+
+    /// The current task-local logger.
+    ///
+    /// Returns the logger bound by the nearest enclosing ``withLogger(_:_:)`` scope.
+    /// If none has been set up, returns a fallback logger: the globally bootstrapped
+    /// handler if ``LoggingSystem/bootstrap(_:)`` has been called, otherwise a silent
+    /// ``SwiftLogNoOpLogHandler``. The unbootstrapped case emits a one-time warning on
+    /// stderr so silent dropped logs can be diagnosed.
+    ///
+    /// The bootstrapped fallback invokes `LoggingSystem.factory` on every access — for
+    /// hot paths, wrap your entry point in ``withLogger(_:_:)`` and use the closure's
+    /// `logger` parameter (or extract into a local `let`) instead of reading ``current``
+    /// on every call.
+    ///
+    /// Task-local values propagate through structured concurrency (`async let`,
+    /// `withTaskGroup`, child `Task {}`) but are **not** inherited by `Task.detached`.
+    /// Capture the logger explicitly across detached boundaries.
+    public static var current: Logger {
+        Self.taskLocalLogger ?? Self.makeFallbackLogger()
+    }
+}
+
+/// Module-private cached fallback used by ``Logger/current`` when no `LoggingSystem`
+/// bootstrap has been performed. Reused across every access to avoid allocating a fresh
+/// `Logger` and `SwiftLogNoOpLogHandler` on each unbootstrapped read.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+private let _taskLocalNoOpFallback = Logger(label: "task-local-fallback", SwiftLogNoOpLogHandler())
+
+/// Emits a one-time stderr warning the first time the NoOp fallback is returned so a user
+/// who forgot to bootstrap or wrap their entry point in `withLogger` doesn't see silently
+/// dropped logs with no diagnostic.
+private let _noOpFallbackWarnOnce = _NoOpFallbackWarnOnce()
+
+private final class _NoOpFallbackWarnOnce: @unchecked Sendable {
+    private let lock = Lock()
+    private var warned = false
+
+    func warnOnce() {
+        let shouldWarn = self.lock.withLock { () -> Bool in
+            if self.warned { return false }
+            self.warned = true
+            return true
+        }
+        if shouldWarn {
+            var stream = StdioOutputStream.stderr
+            print(
+                """
+                [swift-log] warning: Logger.current accessed without a LoggingSystem \
+                bootstrap; logs will be discarded by the no-op fallback handler. \
+                Call LoggingSystem.bootstrap(_:) at application startup, or bind a logger \
+                with withLogger(_:).
+                """,
+                to: &stream
+            )
+        }
     }
 }
 

--- a/Sources/Logging/LoggingSystem.swift
+++ b/Sources/Logging/LoggingSystem.swift
@@ -101,6 +101,12 @@ public enum LoggingSystem: Sendable {
         }
     }
 
+    /// `true` once a user has explicitly called ``bootstrap(_:)`` or the metadata-provider
+    /// overload; `false` while the system is still using the default `StreamLogHandler`.
+    internal static var isBootstrapped: Bool {
+        self._factory.isInitialized
+    }
+
     /// System wide ``Logger/MetadataProvider`` that was configured during the logging system's `bootstrap`.
     ///
     /// When creating a ``Logger`` using the plain ``Logger/init(label:)`` initializer, this metadata provider
@@ -151,7 +157,7 @@ public enum LoggingSystem: Sendable {
     /// and can only be updated once from the initial value given.
     private struct ReplaceOnceBox<BoxedType: Sendable> {
         private struct ReplaceOnce: Sendable {
-            private var initialized = false
+            private(set) var initialized = false
             private var _underlying: BoxedType
             private let violationErrorMessage: String
 
@@ -188,6 +194,10 @@ public enum LoggingSystem: Sendable {
 
         var underlying: BoxedType {
             self.storage.withReadLock { $0.underlying }
+        }
+
+        var isInitialized: Bool {
+            self.storage.withReadLock { $0.initialized }
         }
     }
 

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -212,6 +212,14 @@ extension GlobalLoggerTest {
             metadata: ["provider": "42", "one-off": "42"]
         )
     }
+
+    @Test func taskLocalFallbackUsesBootstrappedHandler() {
+        let logging = TestLogging()
+        LoggingSystem.bootstrapInternal(logging.make)
+
+        Logger.current.warning("from fallback")
+        logging.history.assertExist(level: .warning, message: "from fallback")
+    }
 }
 
 private struct Struct1 {

--- a/Tests/LoggingTests/TaskLocalLoggerTest.swift
+++ b/Tests/LoggingTests/TaskLocalLoggerTest.swift
@@ -1,0 +1,371 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import Logging
+
+struct TaskLocalLoggerTest {
+    // MARK: - Binding a logger
+
+    @Test func bindLogger() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { logger in
+            logger.info("bound")
+        }
+
+        logging.history.assertExist(level: .info, message: "bound")
+    }
+
+    @Test func bindLoggerAsyncReturning() async {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        let result = await withLogger(logger) { logger -> Int in
+            await Task.yield()
+            logger.info("computing")
+            return 42
+        }
+
+        #expect(result == 42)
+        logging.history.assertExist(level: .info, message: "computing")
+    }
+
+    /// The bind overload replaces the task-local logger; accumulated metadata from an
+    /// enclosing `withLogger(mergingMetadata:)` scope is intentionally not carried over.
+    @Test func bindReplacesAccumulatedMetadata() {
+        let logging1 = TestLogging()
+        let logging2 = TestLogging()
+        let root = Logger(label: "root", factory: { logging1.make(label: $0) })
+        let other = Logger(label: "other", factory: { logging2.make(label: $0) })
+
+        withLogger(root) { _ in
+            withLogger(mergingMetadata: ["request.id": "r1"]) { _ in
+                withLogger(other) { inner in
+                    inner.info("no request.id")
+                }
+            }
+        }
+
+        let entry = logging2.history.entries.first { $0.message == "no request.id" }
+        #expect(entry?.metadata?["request.id"] == nil)
+    }
+
+    // MARK: - Modifying the current logger
+
+    @Test func mergeMetadata() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["key": "value"]) { logger in
+                logger.info("merged")
+            }
+        }
+
+        logging.history.assertExist(level: .info, message: "merged", metadata: ["key": "value"])
+    }
+
+    @Test func overrideLogLevel() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { _ in
+            withLogger(logLevel: .warning) { logger in
+                logger.debug("suppressed")
+                logger.warning("emitted")
+            }
+        }
+
+        logging.history.assertNotExist(level: .debug, message: "suppressed")
+        logging.history.assertExist(level: .warning, message: "emitted")
+    }
+
+    @Test func nestedMetadataAccumulates() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["level1": "first"]) { _ in
+                withLogger(mergingMetadata: ["level2": "second"]) { logger in
+                    logger.info("inner")
+                }
+            }
+        }
+
+        logging.history.assertExist(
+            level: .info,
+            message: "inner",
+            metadata: ["level1": "first", "level2": "second"]
+        )
+    }
+
+    @Test func innerMetadataOverridesOuter() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["key": "outer"]) { _ in
+                withLogger(mergingMetadata: ["key": "inner"]) { logger in
+                    logger.info("test")
+                }
+            }
+        }
+
+        logging.history.assertExist(level: .info, message: "test", metadata: ["key": "inner"])
+    }
+
+    /// `withLogger(label:)` rebrands the current logger but inherits metadata from the
+    /// enclosing scope — the pattern a library wants when it logs under its own label
+    /// while the caller's `request.id` and friends come along. The rebrand must also
+    /// preserve the handler's log level and any base metadata the handler carried before
+    /// the outer `withLogger` scope (i.e. metadata that isn't merged via a scope).
+    @Test func labelRebrandsKeepingMetadata() {
+        let logging = TestLogging()
+        var logger = Logger(label: "app", factory: { logging.make(label: $0) })
+        logger.logLevel = .warning
+        logger[metadataKey: "app.version"] = "1.0"  // base metadata on the handler
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["request.id": "r1"]) { _ in
+                withLogger(label: "postgres-client") { libraryLogger in
+                    #expect(libraryLogger.label == "postgres-client")
+                    #expect(libraryLogger.logLevel == .warning)
+                    libraryLogger.info("should not appear (below log level)")
+                    libraryLogger.warning("Executing query")
+                }
+            }
+        }
+
+        logging.history.assertNotExist(level: .info, message: "should not appear (below log level)")
+
+        let entry = logging.history.entries.first { $0.message == "Executing query" }
+        #expect(entry?.metadata?["request.id"] == "r1")
+        #expect(entry?.metadata?["app.version"] == "1.0")
+    }
+
+    /// `withLogger(handler:)` routes logs to a different handler for the scope — the
+    /// canonical use is swapping in an in-memory handler to capture logs for assertions
+    /// in a test.
+    @Test func handlerSwapsForScope() {
+        let outer = TestLogging()
+        let inner = TestLogging()
+        let appLogger = Logger(label: "app", factory: { outer.make(label: $0) })
+
+        withLogger(appLogger) { _ in
+            for _ in outer.history.entries {}  // touch outer so we can see the drift
+            withLogger(handler: inner.make(label: "captured"), mergingMetadata: ["case": "test"]) { scoped in
+                scoped.info("emitted under inner handler")
+            }
+            appLogger.info("back under outer")
+        }
+
+        inner.history.assertExist(
+            level: .info,
+            message: "emitted under inner handler",
+            metadata: ["case": "test"]
+        )
+        inner.history.assertNotExist(level: .info, message: "back under outer")
+        outer.history.assertExist(level: .info, message: "back under outer")
+        outer.history.assertNotExist(level: .info, message: "emitted under inner handler")
+    }
+
+    @Test func siblingScopesAreIsolated() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["a": "1"]) { logger in
+                logger.info("first")
+            }
+            withLogger(mergingMetadata: ["b": "2"]) { logger in
+                logger.info("second")
+            }
+        }
+
+        let second = logging.history.entries.first { $0.message == "second" }
+        #expect(second?.metadata?["a"] == nil)
+        #expect(second?.metadata?["b"] == "2")
+    }
+
+    // MARK: - Async propagation and task isolation
+
+    @Test func contextPreservedAcrossAwait() async throws {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        try await withLogger(logger) { _ in
+            try await withLogger(mergingMetadata: ["request": "123"]) { logger in
+                logger.info("before await")
+                await Task.yield()
+                logger.info("after await")
+            }
+        }
+
+        logging.history.assertExist(level: .info, message: "before await", metadata: ["request": "123"])
+        logging.history.assertExist(level: .info, message: "after await", metadata: ["request": "123"])
+    }
+
+    @Test func childTaskInheritsContextDetachedDoesNot() async {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        await withLogger(logger) { _ in
+            await withLogger(mergingMetadata: ["parent": "value"]) { _ in
+                await Task {
+                    Logger.current.info("child")
+                }.value
+                await Task.detached {
+                    Logger.current.info("detached")
+                }.value
+            }
+        }
+
+        logging.history.assertExist(level: .info, message: "child", metadata: ["parent": "value"])
+        // Detached task uses the NoOp fallback and does not reach our TestLogging.
+        logging.history.assertNotExist(level: .info, message: "detached")
+    }
+
+    @Test func concurrentTasksHaveIndependentContext() async {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        await withLogger(logger) { _ in
+            await withLogger(mergingMetadata: ["context": "parent"]) { _ in
+                await withTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        withLogger(mergingMetadata: ["task": "1"]) { logger in
+                            logger.info("task 1")
+                        }
+                    }
+                    group.addTask {
+                        withLogger(mergingMetadata: ["task": "2"]) { logger in
+                            logger.info("task 2")
+                        }
+                    }
+                }
+            }
+        }
+
+        logging.history.assertExist(
+            level: .info,
+            message: "task 1",
+            metadata: ["task": "1", "context": "parent"]
+        )
+        logging.history.assertExist(
+            level: .info,
+            message: "task 2",
+            metadata: ["task": "2", "context": "parent"]
+        )
+    }
+
+    @Test func asyncLetInheritsContext() async {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        func observedScope() async -> String? {
+            Logger.current.handler.metadata["scope"]?.description
+        }
+
+        await withLogger(logger) { _ in
+            await withLogger(mergingMetadata: ["scope": "parent"]) { _ in
+                async let inherited = observedScope()
+                let observed = await inherited
+                #expect(observed == "parent")
+            }
+        }
+    }
+
+    // MARK: - Error propagation
+
+    @Test func bindPropagatesThrow() {
+        struct TestError: Error {}
+        #expect(throws: TestError.self) {
+            try withLogger(Logger(label: "t")) { _ in
+                throw TestError()
+            }
+        }
+    }
+
+    @Test func modifyAsyncPropagatesThrow() async {
+        struct TestError: Error {}
+        await #expect(throws: TestError.self) {
+            try await withLogger(mergingMetadata: ["k": "v"]) { _ in
+                throw TestError()
+            }
+        }
+    }
+
+    // MARK: - Fallback behavior
+
+    @Test func fallbackIsNoOpWithoutBootstrap() {
+        // The fallback logger carries the canonical label whether it's bootstrapped or NoOp.
+        // (Metadata behavior under NoOp is not directly observable and depends on whether
+        // any earlier test bootstrapped the LoggingSystem.)
+        withLogger(mergingMetadata: ["key": "value"]) { logger in
+            #expect(logger.label == "task-local-fallback")
+        }
+    }
+
+    // MARK: - Real-world patterns
+
+    @Test func libraryReadsCurrentWithoutLoggerParameter() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        struct DatabaseClient {
+            func query(_ sql: String) {
+                Logger.current.debug("query", metadata: ["sql": "\(sql)"])
+            }
+        }
+
+        withLogger(logger) { _ in
+            withLogger(mergingMetadata: ["request.id": "123"]) { _ in
+                DatabaseClient().query("SELECT 1")
+            }
+        }
+
+        logging.history.assertExist(
+            level: .debug,
+            message: "query",
+            metadata: ["request.id": "123", "sql": "SELECT 1"]
+        )
+    }
+
+    // MARK: - Stress
+
+    @Test func deeplyNestedScopes() {
+        let logging = TestLogging()
+        let logger = Logger(label: "test", factory: { logging.make(label: $0) })
+
+        func nest(depth: Int) {
+            if depth == 0 {
+                Logger.current.info("bottom")
+                return
+            }
+            withLogger(mergingMetadata: ["d-\(depth)": "\(depth)"]) { _ in
+                nest(depth: depth - 1)
+            }
+        }
+
+        withLogger(logger) { _ in
+            nest(depth: 20)
+        }
+
+        let entry = logging.history.entries.first { $0.message == "bottom" }
+        #expect(entry?.metadata?.count == 20)
+    }
+}


### PR DESCRIPTION
This proposal adds task-local logger storage to enable progressive metadata accumulation without explicit logger parameters. It focuses on solving metadata propagation challenges in applications and libraries.

### Motivation:

Modern Swift applications face challenges when trying to maintain rich, contextual logging with accumulated metadata.

### Modifications:

Implemented Swift's `@TaskLocal` storage to automatically propagate logger with accumulated metadata outlined in the SLG-0006.

### Result:

Logger object and metadata can be propagated through Swift structured concurrency.
