### PR TITLE
SLG-0004: Metadata privacy levels proposal

### DIFF
--- a/Sources/Logging/Docs.docc/Proposals/SLG-0004-metadata-values-privacy-attributes.md
+++ b/Sources/Logging/Docs.docc/Proposals/SLG-0004-metadata-values-privacy-attributes.md
@@ -6,12 +6,13 @@ Introduce an attributed metadata system that allows attaching attributes to meta
 
 - Proposal: SLG-0004
 - Author(s): [Vladimir Kukushkin](https://github.com/kukushechkin)
-- Status: **Awaiting Review**
+- Status: **Deferred**
 - Issue: https://github.com/apple/swift-log/issues/204
 - Implementation:
     - [apple/swift-log#418](https://github.com/apple/swift-log/pull/418)
 - Related links:
     - [Lightweight proposals process description](https://github.com/apple/swift-log/blob/main/Sources/Logging/Docs.docc/Proposals/Proposals.md)
+    - [Review discussion](https://forums.swift.org/t/proposal-slg-0004-metadata-values-privacy-attribute/85249/16)
 
 ### Introduction
 


### PR DESCRIPTION
This proposal introduces an **attributed metadata system** that allows attaching attributes to metadata values. Privacy level is the first concrete attribute, enabling developers to mark metadata values as `.private` or `.public` so `LogHandler` implementations can redact sensitive values before logging.

### Motivation:

SwiftLog lacks a mechanism to attach attributes to metadata values as sensitive to allow Log Handlers to control logging behavior.

### Modifications:

Added the SLG-004 proposal, introducing attributed metadata values mechanism and privacy levels for metadata values.

### Result:

Proposal is ready for review.
