### PR TITLE
Fix benchmarks — traits are only available in 6.1+

### DIFF
--- a/Benchmarks/MaxLogLevelWarning/Package.swift
+++ b/Benchmarks/MaxLogLevelWarning/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Bump tools version in benchmark package manifests to 6.1.

### Motivation:

Benchmarks are using a feature of SPM — traits, which is available in Swift 6.1+.

### Modifications:

Tools version is updated.

### Result:

Benchmarks run in CI.
