### PR TITLE
`Logger.MetadataProvider.multiplex` to not return optional

### DIFF
--- a/Sources/Logging/MetadataProvider.swift
+++ b/Sources/Logging/MetadataProvider.swift
@@ -86,7 +86,7 @@ extension Logger.MetadataProvider {
     ///
     /// - Parameter providers: An array of `MetadataProvider`s to delegate to. The array must not be empty.
     /// - Returns: A pseudo-`MetadataProvider` merging metadata from the given `MetadataProvider`s.
-    public static func multiplex(_ providers: [Logger.MetadataProvider]) -> Logger.MetadataProvider? {
+    public static func multiplex(_ providers: [Logger.MetadataProvider]) -> Logger.MetadataProvider {
         assert(!providers.isEmpty, "providers MUST NOT be empty")
         return Logger.MetadataProvider {
             providers.reduce(into: [:]) { metadata, provider in


### PR DESCRIPTION
### Motivation:

Just ran into this at work. Unless there is some reasoning I can't find on the repo or forums, this is a basic type discrepancy from [SLG-0001](https://github.com/apple/swift-log/blob/6f3fbace6629c8fcabcd56d211501e92e1919a94/Sources/Logging/Docs.docc/Proposals/SLG-0001-metadata-providers.md?plain=1#L161) and an instance is always provided anyways.