### PR TITLE
Update documentation to reflect recent changes

### DIFF
--- a/Sources/Logging/Docs.docc/ImplementingALogHandler.md
+++ b/Sources/Logging/Docs.docc/ImplementingALogHandler.md
@@ -23,11 +23,11 @@ func logHandlerValueSemantics() {
     var logger1 = Logger(label: "first logger")
     logger1.logLevel = .debug
     logger1[metadataKey: "only-on"] = "first"
-    
+
     var logger2 = logger1
     logger2.logLevel = .error                  // Must not affect logger1
     logger2[metadataKey: "only-on"] = "second" // Must not affect logger1
-    
+
     // These expectations must pass
     #expect(logger1.logLevel == .debug)
     #expect(logger2.logLevel == .error)
@@ -51,37 +51,29 @@ public struct PrintLogHandler: LogHandler {
     private let label: String
     public var logLevel: Logger.Level = .info
     public var metadata: Logger.Metadata = [:]
-    
+
     public init(label: String) {
         self.label = label
     }
-    
-    public func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+
+    public func log(event: LogEvent) {
         let timestamp = ISO8601DateFormatter().string(from: Date())
-        let levelString = level.rawValue.uppercased()
-        
+        let levelString = event.level.rawValue.uppercased()
+
         // Merge handler metadata with message metadata
         let combinedMetadata = Self.prepareMetadata(
             base: self.metadata
-            explicit: metadata
+            explicit: event.metadata
         )
-        
+
         // Format metadata
         let metadataString = combinedMetadata.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
-        
+
         // Create log line and print to console
-        let logLine = "\(label) \(timestamp) \(levelString) [\(metadataString)]: \(message)"
+        let logLine = "\(label) \(timestamp) \(levelString) [\(metadataString)]: \(event.message)"
         print(logLine)
     }
-    
+
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get {
             return self.metadata[key]
@@ -128,23 +120,15 @@ public struct PrintLogHandler: LogHandler {
     public var logLevel: Logger.Level = .info
     public var metadata: Logger.Metadata = [:]
     public var metadataProvider: Logger.MetadataProvider?
-    
+
     public init(label: String) {
         self.label = label
     }
-    
-    public func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+
+    public func log(event: LogEvent) {
         let timestamp = ISO8601DateFormatter().string(from: Date())
-        let levelString = level.rawValue.uppercased()
-        
+        let levelString = event.level.rawValue.uppercased()
+
         // Get provider metadata
         let providerMetadata = metadataProvider?.get() ?? [:]
 
@@ -152,17 +136,17 @@ public struct PrintLogHandler: LogHandler {
         let combinedMetadata = Self.prepareMetadata(
             base: self.metadata,
             provider: self.metadataProvider,
-            explicit: metadata
+            explicit: event.metadata
         )
-        
+
         // Format metadata
         let metadataString = combinedMetadata.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
-        
+
         // Create log line and print to console
-        let logLine = "\(label) \(timestamp) \(levelString) [\(metadataString)]: \(message)"
+        let logLine = "\(label) \(timestamp) \(levelString) [\(metadataString)]: \(event.message)"
         print(logLine)
     }
-    
+
     public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get {
             return self.metadata[key]

--- a/Sources/Logging/Docs.docc/ImplementingALogHandler.md
+++ b/Sources/Logging/Docs.docc/ImplementingALogHandler.md
@@ -62,7 +62,7 @@ public struct PrintLogHandler: LogHandler {
 
         // Merge handler metadata with message metadata
         let combinedMetadata = Self.prepareMetadata(
-            base: self.metadata
+            base: self.metadata,
             explicit: event.metadata
         )
 

--- a/Sources/Logging/Docs.docc/Reference/LogEvent.md
+++ b/Sources/Logging/Docs.docc/Reference/LogEvent.md
@@ -1,0 +1,7 @@
+# ``Logging/LogEvent``
+
+## Topics
+
+### Creating a log event
+
+- ``init(level:message:metadata:source:file:function:line:)``

--- a/Sources/Logging/Docs.docc/Reference/LogHandler.md
+++ b/Sources/Logging/Docs.docc/Reference/LogHandler.md
@@ -4,6 +4,8 @@
 
 ### Sending log messages
 
+- ``log(event:)-7x67``
+- ``log(event:)-17f2r``
 - ``log(level:message:metadata:source:file:function:line:)-8kgt7``
 - ``log(level:message:metadata:source:file:function:line:)-69pez``
 - ``log(level:message:metadata:file:function:line:)-89rya``

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -14,35 +14,49 @@
 
 - ``trace(_:metadata:file:function:line:)``
 - ``trace(_:metadata:source:file:function:line:)``
+- ``trace(_:error:metadata:source:file:function:line:)``
 
 ### Sending debug log messages
+
 - ``debug(_:metadata:file:function:line:)``
 - ``debug(_:metadata:source:file:function:line:)``
+- ``debug(_:error:metadata:source:file:function:line:)``
 
 ### Sending info log messages
+
 - ``info(_:metadata:file:function:line:)``
 - ``info(_:metadata:source:file:function:line:)``
+- ``info(_:error:metadata:source:file:function:line:)``
 
 ### Sending notice log messages
+
 - ``notice(_:metadata:file:function:line:)``
 - ``notice(_:metadata:source:file:function:line:)``
+- ``notice(_:error:metadata:source:file:function:line:)``
 
 ### Sending warning log messages
+
 - ``warning(_:metadata:file:function:line:)``
 - ``warning(_:metadata:source:file:function:line:)``
+- ``warning(_:error:metadata:source:file:function:line:)``
 
 ### Sending error log messages
+
 - ``error(_:metadata:file:function:line:)``
 - ``error(_:metadata:source:file:function:line:)``
+- ``error(_:error:metadata:source:file:function:line:)``
 
 ### Sending critical log messages
+
 - ``critical(_:metadata:file:function:line:)``
 - ``critical(_:metadata:source:file:function:line:)``
+- ``critical(_:error:metadata:source:file:function:line:)``
 
 ### Sending general log messages
 
 - ``log(level:_:metadata:file:function:line:)``
 - ``log(level:_:metadata:source:file:function:line:)``
+- ``log(level:_:error:metadata:source:file:function:line:)``
 - ``Level``
 - ``Message``
 - ``Metadata``

--- a/Sources/Logging/Docs.docc/Reference/MultiplexLogHandler.md
+++ b/Sources/Logging/Docs.docc/Reference/MultiplexLogHandler.md
@@ -9,6 +9,7 @@
 
 ### Sending log messages
 
+- ``log(event:)``
 - ``log(level:message:metadata:source:file:function:line:)``
 
 ### Updating metadata

--- a/Sources/Logging/Docs.docc/Reference/StreamLogHandler.md
+++ b/Sources/Logging/Docs.docc/Reference/StreamLogHandler.md
@@ -11,6 +11,7 @@
 
 ### Sending log messages
 
+- ``log(event:)``
 - ``log(level:message:metadata:source:file:function:line:)``
 
 ### Updating metadata

--- a/Sources/Logging/Docs.docc/Reference/SwiftLogNoOpLogHandler.md
+++ b/Sources/Logging/Docs.docc/Reference/SwiftLogNoOpLogHandler.md
@@ -9,7 +9,9 @@
 
 ### Sending log messages
 
+- ``log(event:)``
 - ``log(level:message:metadata:source:file:function:line:)``
+- ``log(level:message:metadata:file:function:line:)``
 
 ### Updating metadata
 

--- a/Sources/Logging/Docs.docc/index.md
+++ b/Sources/Logging/Docs.docc/index.md
@@ -84,6 +84,7 @@ backend.
 ### Log Handlers
 
 - ``LogHandler``
+- ``LogEvent``
 - ``MultiplexLogHandler``
 - ``StreamLogHandler``
 - ``SwiftLogNoOpLogHandler``

--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -96,14 +96,7 @@
 ///         }
 ///     }
 ///
-///     public func log(
-///         level: Logger.Level,
-///         message: Logger.Message,
-///         metadata: Logger.Metadata?,
-///         source: String,
-///         file: String,
-///         function: String,
-///         line: UInt) {
+///     public func log(event: LogEvent) {
 ///         // [...]
 ///     }
 ///


### PR DESCRIPTION
Update documentation to reflect recent changes

### Motivation:

The documentation was not updated in SLG-0003 or SLG-0005. Concretely, the examples given in the documentation used the now deprecated multiparameter methods in `LogHandler`, and the new `LogEvent`-based method were not listed among the others. Likewise, the new logging methods (`Logger.trace` etc.) that take an `Error` as a parameter were not added. Lastly, `LogEvent` had no separate entry. 
While the default rendered docs for these were acceptable, it decreased the discoverability of the new methods, and the examples using deprecated methods were misleading.

### Modifications:

* Update all code examples to use non-deprecated methods.
* List all new methods on `Logger` and `LogHandler` along the existing ones.
* Add a minimal file for `LogEvent` to give it the same look as all other types.
* Update code examples in `.md` files to follow swift format.

### Result:

Documentation reflects the current state and best practices of `swift-log`.