### PR TITLE
Add tests for SwiftLogNoOpLogHandler

### DIFF
--- a/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
+++ b/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
@@ -48,11 +48,11 @@ struct SwiftLogNoOpLogHandlerTest {
         #expect(handler[metadataKey: "key"] == nil)
     }
 
-    @Test func logEventIsDiscarded() {
+    @Test func logEventDoesNotCrash() {
         let handler = SwiftLogNoOpLogHandler()
         let event = LogEvent(
             level: .critical,
-            message: "should be discarded",
+            message: "message",
             metadata: ["key": "value"],
             source: "test",
             file: #file,
@@ -62,7 +62,7 @@ struct SwiftLogNoOpLogHandlerTest {
         handler.log(event: event)
     }
 
-    @Test func loggerUsingNoOpHandlerSilentlyDiscards() {
+    @Test func allLogLevelsDoNotCrash() {
         var logger = Logger(label: "noop.test", factory: { _ in SwiftLogNoOpLogHandler() })
         logger[metadataKey: "key"] = "value"
         logger.trace("trace message")

--- a/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
+++ b/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import Logging
+
+struct SwiftLogNoOpLogHandlerTest {
+    @Test func initWithNoArguments() {
+        let handler = SwiftLogNoOpLogHandler()
+        #expect(handler.logLevel == .critical)
+        #expect(handler.metadata == [:])
+    }
+
+    @Test func initWithLabel() {
+        let handler = SwiftLogNoOpLogHandler("some.label")
+        #expect(handler.logLevel == .critical)
+        #expect(handler.metadata == [:])
+    }
+
+    @Test func logLevelIgnoresMutations() {
+        var handler = SwiftLogNoOpLogHandler()
+        handler.logLevel = .trace
+        #expect(handler.logLevel == .critical)
+    }
+
+    @Test func metadataIgnoresMutations() {
+        var handler = SwiftLogNoOpLogHandler()
+        handler.metadata = ["key": "value"]
+        #expect(handler.metadata == [:])
+    }
+
+    @Test func metadataSubscriptAlwaysReturnsNil() {
+        var handler = SwiftLogNoOpLogHandler()
+        #expect(handler[metadataKey: "key"] == nil)
+        handler[metadataKey: "key"] = "value"
+        #expect(handler[metadataKey: "key"] == nil)
+    }
+
+    @Test func logEventIsDiscarded() {
+        let handler = SwiftLogNoOpLogHandler()
+        let event = LogEvent(
+            level: .critical,
+            message: "should be discarded",
+            metadata: ["key": "value"],
+            source: "test",
+            file: #file,
+            function: #function,
+            line: #line
+        )
+        handler.log(event: event)
+    }
+
+    @Test func loggerUsingNoOpHandlerSilentlyDiscards() {
+        var logger = Logger(label: "noop.test", factory: { _ in SwiftLogNoOpLogHandler() })
+        logger[metadataKey: "key"] = "value"
+        logger.trace("trace message")
+        logger.debug("debug message")
+        logger.info("info message")
+        logger.notice("notice message")
+        logger.warning("warning message")
+        logger.error("error message")
+        logger.critical("critical message")
+    }
+}


### PR DESCRIPTION
Add tests for SwiftLogNoOpLogHandler

### Motivation:

`SwiftLogNoOpLogHandler` is a public type with no dedicated test coverage.

### Modifications:

* Add tests for both initialisers, `logLevel`, `metadata`, the metadata subscript, `log(event:)`, and end-to-end usage via `Logger`.

### Result:

`SwiftLogNoOpLogHandler` has test coverage on par with other handlers.
Coverage from 89% over all tests, to 90%.
