### PR TITLE
Remove stale CONTRIBUTORS.txt header references

### DIFF
--- a/Benchmarks/MaxLogLevelWarning/Benchmarks/MaxLogLevelWarningBenchmarks/MaxLogLevelWarning.swift
+++ b/Benchmarks/MaxLogLevelWarning/Benchmarks/MaxLogLevelWarningBenchmarks/MaxLogLevelWarning.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Benchmarks/NoTraits/Benchmarks/NoTraitsBenchmarks/NoTraits.swift
+++ b/Benchmarks/NoTraits/Benchmarks/NoTraitsBenchmarks/NoTraits.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
+++ b/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Benchmarks/Sources/BenchmarksFactory/NoOpLogHandler.swift
+++ b/Benchmarks/Sources/BenchmarksFactory/NoOpLogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/InMemoryLogging/InMemoryLogHandler.swift
+++ b/Sources/InMemoryLogging/InMemoryLogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/Handlers/MultiplexLogHandler.swift
+++ b/Sources/Logging/Handlers/MultiplexLogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/Handlers/StreamLogHandler.swift
+++ b/Sources/Logging/Handlers/StreamLogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/Handlers/SwiftLogNoOpLogHandler.swift
+++ b/Sources/Logging/Handlers/SwiftLogNoOpLogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,7 +19,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/LogEvent.swift
+++ b/Sources/Logging/LogEvent.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/LogHandler.swift
+++ b/Sources/Logging/LogHandler.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/LoggingSystem.swift
+++ b/Sources/Logging/LoggingSystem.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Sources/Logging/MetadataProvider.swift
+++ b/Sources/Logging/MetadataProvider.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/InMemoryLoggingTests/InMemoryLogHandlerTests.swift
+++ b/Tests/InMemoryLoggingTests/InMemoryLogHandlerTests.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/CompatibilityTest.swift
+++ b/Tests/LoggingTests/CompatibilityTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/GlobalLoggingTest.swift
+++ b/Tests/LoggingTests/GlobalLoggingTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/LocalLoggingTest.swift
+++ b/Tests/LoggingTests/LocalLoggingTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/LockTest.swift
+++ b/Tests/LoggingTests/LockTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -20,7 +19,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/LogEventTest.swift
+++ b/Tests/LoggingTests/LogEventTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/MDCTest.swift
+++ b/Tests/LoggingTests/MDCTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/MetadataProviderTest.swift
+++ b/Tests/LoggingTests/MetadataProviderTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/StreamLogHandlerTest.swift
+++ b/Tests/LoggingTests/StreamLogHandlerTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/SubDirectoryOfLoggingTests/EmitALogFromSubDirectory.swift
+++ b/Tests/LoggingTests/SubDirectoryOfLoggingTests/EmitALogFromSubDirectory.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
+++ b/Tests/LoggingTests/SwiftLogNoOpLogHandlerTest.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/TestLogger.swift
+++ b/Tests/LoggingTests/TestLogger.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/Tests/LoggingTests/TestSendable.swift
+++ b/Tests/LoggingTests/TestSendable.swift
@@ -6,7 +6,6 @@
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Remove stale `CONTRIBUTORS.txt` references from file headers.

### Motivation:

Follow-up to #451 and related to #450.

`CONTRIBUTORS.txt` was removed as part of the repository cleanup, but several source, test, and benchmark file headers still referenced it. Since the file no longer exists, those references are now stale.

### Modifications:

Removed the `See CONTRIBUTORS.txt...` header line from the remaining files across `Sources`, `Tests`, and `Benchmarks`.

### Result:

File headers no longer reference the deleted `CONTRIBUTORS.txt` file.