### PR TITLE
Disable nightly 6.3 WASM builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,8 @@ jobs:
   wasm:
     name: Wasm Swift SDK
     uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    with:
+      nightly_next_enabled: false
 
   android:
     name: Android Swift SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,3 +88,5 @@ jobs:
   wasm:
     name: Wasm Swift SDK
     uses: apple/swift-nio/.github/workflows/wasm_swift_sdk.yml@main
+    with:
+      nightly_next_enabled: false


### PR DESCRIPTION
Disable nightly WASM builds because 6.3 images are no longer available. Enable back when 6.4 builds are available.