### PR TITLE
Skip handler dispatch for setters under `MaxLogLevelNone`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,14 @@ jobs:
       benchmark_package_path: "Benchmarks/MaxLogLevelWarning"
       macos_swift_6_3_enabled: true
 
+  macos-benchmarks-MaxLogLevelNoneBenchmarks-trait:
+    name: macOS benchmarks (MaxLogLevelNone)
+    needs: macos-benchmarks-MaxLogLevelWarningBenchmarks-trait
+    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
+    with:
+      benchmark_package_path: "Benchmarks/MaxLogLevelNone"
+      macos_swift_6_3_enabled: true
+
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,6 +53,16 @@ jobs:
       macos_runner_pool: general
       macos_swift_6_3_enabled: true
 
+  macos-benchmarks-MaxLogLevelNoneBenchmarks-trait:
+    name: macOS benchmarks (MaxLogLevelNone)
+    # Workaround for reusing the same benchmarks.yml workflow
+    needs: macos-benchmarks-MaxLogLevelWarningBenchmarks-trait
+    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
+    with:
+      benchmark_package_path: "Benchmarks/MaxLogLevelNone"
+      macos_runner_pool: general
+      macos_swift_6_3_enabled: true
+
   cxx-interop:
     name: Cxx interop
     uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main

--- a/Benchmarks/MaxLogLevelNone/.gitignore
+++ b/Benchmarks/MaxLogLevelNone/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Benchmarks/MaxLogLevelNone/Benchmarks/MaxLogLevelNoneBenchmarks/MaxLogLevelNone.swift
+++ b/Benchmarks/MaxLogLevelNone/Benchmarks/MaxLogLevelNoneBenchmarks/MaxLogLevelNone.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import BenchmarksFactory
+import Foundation
+import Logging
+
+public let benchmarks: @Sendable () -> Void = {
+    makeBenchmark(loggerLevel: .critical, logLevel: .critical) { logger in
+        logger.critical("hello, benchmarking world")
+    }
+    makeBenchmark(loggerLevel: .critical, logLevel: .critical, "_generic") { logger in
+        logger.log(level: .critical, "hello, benchmarking world")
+    }
+    makeBenchmark(loggerLevel: .critical, logLevel: .critical, "_metadata_set") { logger in
+        var logger = logger
+        logger[metadataKey: "user-id"] = "42"
+    }
+    makeBenchmark(loggerLevel: .critical, logLevel: .critical, "_logLevel_set") { logger in
+        var logger = logger
+        logger.logLevel = .info
+    }
+}

--- a/Benchmarks/MaxLogLevelNone/Package.swift
+++ b/Benchmarks/MaxLogLevelNone/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MaxLogLevelNone",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "MaxLogLevelNone", targets: ["MaxLogLevelNone"])
+    ],
+    dependencies: [
+        // swift-log
+        .package(
+            path: "../../",
+            traits: ["MaxLogLevelNone"]
+        ),
+        // Parent Benchmarks
+        .package(name: "Benchmarks", path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.29.6"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MaxLogLevelNone",
+            dependencies: [
+                .product(name: "BenchmarksFactory", package: "Benchmarks"),
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            path: "Benchmarks/MaxLogLevelNoneBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        )
+    ]
+)

--- a/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level.p90.json
+++ b/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level.p90.json
@@ -1,0 +1,4 @@
+{
+  "instructions" : 658,
+  "objectAllocCount" : 0
+}

--- a/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_generic.p90.json
+++ b/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_generic.p90.json
@@ -1,0 +1,4 @@
+{
+  "instructions" : 658,
+  "objectAllocCount" : 0
+}

--- a/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_logLevel_set.p90.json
+++ b/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_logLevel_set.p90.json
@@ -1,0 +1,4 @@
+{
+  "instructions" : 658,
+  "objectAllocCount" : 0
+}

--- a/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_metadata_set.p90.json
+++ b/Benchmarks/MaxLogLevelNone/Thresholds/Xcode swift 6.3/MaxLogLevelNone.critical_log_with_critical_log_level_metadata_set.p90.json
@@ -1,0 +1,4 @@
+{
+  "instructions" : 658,
+  "objectAllocCount" : 0
+}

--- a/Benchmarks/MaxLogLevelWarning/Package.swift
+++ b/Benchmarks/MaxLogLevelWarning/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Benchmarks/NoTraits/Package.swift
+++ b/Benchmarks/NoTraits/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
+++ b/Benchmarks/Sources/BenchmarksFactory/MakeBenchmark.swift
@@ -39,7 +39,7 @@ public func makeBenchmark(
             thresholds: [
                 .instructions: BenchmarkThresholds(
                     relative: [
-                        .p90: 2.0  // we only record p90
+                        .p90: 10.0  // we only record p90
                     ]
                 ),
                 .objectAllocCount: BenchmarkThresholds(

--- a/Sources/Logging/Docs.docc/DisableLogLevelsDuringCompilation.md
+++ b/Sources/Logging/Docs.docc/DisableLogLevelsDuringCompilation.md
@@ -71,3 +71,12 @@ logger.error("This still works")
 logger.critical("This still works")
 logger.log(level: .error, "This still works")
 ```
+
+When `MaxLogLevelNone` is enabled no log statement can ever fire, so
+mutations that only configure the underlying ``LogHandler`` for future log
+statements are also compiled out. Specifically, the body of the
+``Logger/subscript(metadataKey:)`` setter and the body of the
+``Logger/logLevel`` setter become empty, so calls like
+`logger[metadataKey: "user-id"] = "\(id)"` and `logger.logLevel = .info`
+do not reach the handler. Reads continue to work and return whatever the
+handler reports.

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -325,7 +325,9 @@ extension Logger {
             self.handler[metadataKey: metadataKey]
         }
         set {
+            #if !MaxLogLevelNone
             self.handler[metadataKey: metadataKey] = newValue
+            #endif
         }
     }
 
@@ -341,7 +343,9 @@ extension Logger {
             self.handler.logLevel
         }
         set {
+            #if !MaxLogLevelNone
             self.handler.logLevel = newValue
+            #endif
         }
     }
 }


### PR DESCRIPTION
 Skip handler dispatch for setters under `MaxLogLevelNone`

 ### Motivation

* When `MaxLogLevelNone` is enabled every `Logger.trace`/`debug`/.../`critical` method and `Logger.log(level:)` compiles down to an empty body, so no log statement can ever observe what the underlying `LogHandler` sees.
* Despite this, the `subscript(metadataKey:)` and `logLevel` setters still went through the handler. Code like `logger[metadataKey: "user-id"] = "\(id)"` would CoW the logger storage and call into the handler even though nothing could read the metadata back out via a log statement.

### Modifications

* Wrap the bodies of `Logger.subscript(metadataKey:) { set }` and `Logger.logLevel { set }` in `#if !MaxLogLevelNone`, mirroring the existing guards on the level-specific log methods.
* Note this behaviour in `DisableLogLevelsDuringCompilation.md` so callers know reads still go through the handler but writes do not.
* Add a new benchmark which ensures that the operations don't allocate.
* Update some missed swift-tools-version bumps.
* Loosen p90 instruction threshold to 10%. The same source produces results that swing by up to ~8% between back-to-back runs.
### Result

* `logger[metadataKey:] = ...` and `logger.logLevel = ...` compile to empty bodies when `MaxLogLevelNone` is set, matching the zero-runtime-overhead guarantee the trait already provides for log emission.
* Resolves https://github.com/apple/swift-log/issues/462