### PR TITLE
Adopt multi-package macOS benchmarks workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,27 +31,10 @@ jobs:
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
   macos-benchmarks:
-    name: macOS benchmarks (NoTraits)
+    name: macOS benchmarks
     uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
     with:
-      benchmark_package_path: "Benchmarks/NoTraits"
-      macos_swift_6_2_enabled: true
-      macos_swift_6_3_enabled: true
-
-  macos-benchmarks-MaxLogLevelWarningBenchmarks-trait:
-    name: macOS benchmarks (MaxLogLevelWarning)
-    needs: macos-benchmarks
-    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
-    with:
-      benchmark_package_path: "Benchmarks/MaxLogLevelWarning"
-      macos_swift_6_3_enabled: true
-
-  macos-benchmarks-MaxLogLevelNoneBenchmarks-trait:
-    name: macOS benchmarks (MaxLogLevelNone)
-    needs: macos-benchmarks-MaxLogLevelWarningBenchmarks-trait
-    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
-    with:
-      benchmark_package_path: "Benchmarks/MaxLogLevelNone"
+      benchmark_package_paths: '["Benchmarks/NoTraits", "Benchmarks/MaxLogLevelWarning", "Benchmarks/MaxLogLevelNone"]'
       macos_swift_6_3_enabled: true
 
   cxx-interop:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,31 +35,10 @@ jobs:
       windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
   macos-benchmarks:
-    name: macOS benchmarks (NoTraits)
+    name: macOS benchmarks
     uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
     with:
-      benchmark_package_path: "Benchmarks/NoTraits"
-      macos_runner_pool: general
-      macos_swift_6_2_enabled: true
-      macos_swift_6_3_enabled: true
-
-  macos-benchmarks-MaxLogLevelWarningBenchmarks-trait:
-    name: macOS benchmarks (MaxLogLevelWarning)
-    # Workaround for reusing the same benchmarks.yml workflow
-    needs: macos-benchmarks
-    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
-    with:
-      benchmark_package_path: "Benchmarks/MaxLogLevelWarning"
-      macos_runner_pool: general
-      macos_swift_6_3_enabled: true
-
-  macos-benchmarks-MaxLogLevelNoneBenchmarks-trait:
-    name: macOS benchmarks (MaxLogLevelNone)
-    # Workaround for reusing the same benchmarks.yml workflow
-    needs: macos-benchmarks-MaxLogLevelWarningBenchmarks-trait
-    uses: apple/swift-nio/.github/workflows/macos_benchmarks.yml@main
-    with:
-      benchmark_package_path: "Benchmarks/MaxLogLevelNone"
+      benchmark_package_paths: '["Benchmarks/NoTraits", "Benchmarks/MaxLogLevelWarning", "Benchmarks/MaxLogLevelNone"]'
       macos_runner_pool: general
       macos_swift_6_3_enabled: true
 

--- a/Benchmarks/NoTraits/Thresholds/Xcode swift 6.2/NoTraits.debug_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode swift 6.2/NoTraits.debug_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,0 @@
-{
-  "instructions" : 986,
-  "objectAllocCount" : 0
-}

--- a/Benchmarks/NoTraits/Thresholds/Xcode swift 6.2/NoTraits.error_log_with_error_log_level_generic.p90.json
+++ b/Benchmarks/NoTraits/Thresholds/Xcode swift 6.2/NoTraits.error_log_with_error_log_level_generic.p90.json
@@ -1,4 +1,0 @@
-{
-  "instructions" : 1870,
-  "objectAllocCount" : 0
-}


### PR DESCRIPTION
### Motivation

* The two-invocation pattern for `macos-benchmarks` and `macos-benchmarks-MaxLogLevelWarningBenchmarks-trait` allocates one self-hosted macOS runner per (Swift version x package), incurring duplicate runner-recycling cost.
* The recent change on main adds a `benchmark_package_paths` input letting a single invocation run all packages serially on each runner.

### Modifications

* Replace the two macOS benchmark jobs in `main.yml` and `pull_request.yml` with a single consolidated job that passes both packages via `benchmark_package_paths: '["Benchmarks/NoTraits", "Benchmarks/MaxLogLevelWarning"]'`.
* Drop Swift 6.2 from the matrix; only Swift 6.3 is shared between the two packages (`MaxLogLevelWarning` has no `Thresholds/Xcode swift 6.2/`).

### Result

* One macOS runner allocation per Swift version instead of one per (version x package).
* `NoTraits` loses Swift 6.2 coverage
