### PR TITLE
Add `(default:)` string interpolation overloads

### DIFF
--- a/Sources/Logging/Logger+Attributes.swift
+++ b/Sources/Logging/Logger+Attributes.swift
@@ -391,6 +391,59 @@ extension Logger.MetadataValue: ExpressibleByStringInterpolation {
             self.output.append(String(describing: value))
         }
 
+        // MARK: Optional interpolation with a default
+        // The four overloads below mirror `DefaultStringInterpolation`'s `default:`
+        // shape so that `"\(optional, default: "none")"` keeps working when the
+        // literal is inferred as a `Logger.MetadataValue`.
+
+        @inlinable
+        public mutating func appendInterpolation<T: TextOutputStreamable & CustomStringConvertible>(
+            _ value: T?,
+            default defaultValue: @autoclosure () -> some StringProtocol
+        ) {
+            if let value {
+                self.appendInterpolation(value)
+            } else {
+                self.output.append(String(defaultValue()))
+            }
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<T: TextOutputStreamable>(
+            _ value: T?,
+            default defaultValue: @autoclosure () -> some StringProtocol
+        ) {
+            if let value {
+                self.appendInterpolation(value)
+            } else {
+                self.output.append(String(defaultValue()))
+            }
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<T: CustomStringConvertible>(
+            _ value: T?,
+            default defaultValue: @autoclosure () -> some StringProtocol
+        ) {
+            if let value {
+                self.appendInterpolation(value)
+            } else {
+                self.output.append(String(defaultValue()))
+            }
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<T>(
+            _ value: T?,
+            default defaultValue: @autoclosure () -> some StringProtocol
+        ) {
+            if let value {
+                self.appendInterpolation(value)
+            } else {
+                self.output.append(String(defaultValue()))
+            }
+        }
+
         // MARK: Interpolation with a custom attributes closure
         //
         // ```swift

--- a/Tests/LoggingTests/MetadataValueInterpolationTest.swift
+++ b/Tests/LoggingTests/MetadataValueInterpolationTest.swift
@@ -127,6 +127,69 @@ struct MetadataValueInterpolationTests {
         #expect(value.description == String(describing: box))
     }
 
+    // MARK: - Optional interpolation with a default
+
+    @Test("nil optional uses the default string")
+    func defaultNil() {
+        let value: Int? = nil
+        let result: Logger.MetadataValue = "\(value, default: "none")"
+        #expect(result.description == "none")
+    }
+
+    @Test("non-nil optional interpolates the wrapped value")
+    func defaultSome() {
+        let value: Int? = 42
+        let result: Logger.MetadataValue = "\(value, default: "none")"
+        #expect(result.description == "42")
+    }
+
+    @Test("nil optional of a TOS-only type uses the default")
+    func defaultNilStreamingOnly() {
+        let value: StreamingOnly? = nil
+        let result: Logger.MetadataValue = "\(value, default: "missing")"
+        #expect(result.description == "missing")
+    }
+
+    @Test("non-nil optional of a CSC-only type interpolates via .description")
+    func defaultSomeDescribingOnly() {
+        let value: DescribingOnly? = DescribingOnly(value: 3)
+        let result: Logger.MetadataValue = "\(value, default: "missing")"
+        #expect(result.description == "DO(3)")
+    }
+
+    @Test("nil optional of a non-CSC, non-TOS type uses the default")
+    func defaultNilUnconstrained() {
+        let value: PlainStruct? = nil
+        let result: Logger.MetadataValue = "\(value, default: "absent")"
+        #expect(result.description == "absent")
+    }
+
+    @Test("default accepts a Substring (some StringProtocol)")
+    func defaultSubstring() {
+        let value: Int? = nil
+        let fallback = "n/a value".dropFirst(4)
+        let result: Logger.MetadataValue = "\(value, default: fallback)"
+        #expect(result.description == "value")
+    }
+
+    @Test("default segment mixed with plain segments")
+    func defaultMultiSegment() {
+        let name: String? = nil
+        let result: Logger.MetadataValue = "user=\(name, default: "anon") id=\(42)"
+        #expect(result.description == "user=anon id=42")
+    }
+
+    @Test("default interpolation yields .string case")
+    func defaultYieldsStringCase() {
+        let value: Int? = nil
+        let result: Logger.MetadataValue = "\(value, default: "none")"
+        if case .string(let s) = result {
+            #expect(s == "none")
+        } else {
+            Issue.record("Expected .string case, got \(result)")
+        }
+    }
+
     // MARK: - Overloaded return types
 
     @Test("Overloaded function returning String/Data/[UInt8] disambiguates to String")


### PR DESCRIPTION
Add [Default String Interpolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0477-default-interpolation-values.md) overloads for `MetadataValue` to restore compatibility with `\(default:)` interpolation.

### Motivation:

1.13.0 introduced a breaking change to the default string interpolation compatibility. We do not want to revert the custom string interpolation, but can fix compatibility with the default string interpolation as much as possible.

### Modifications:

Add `\(default:)` overloads to `MetadataValue.StringInterpolation`, similar to the once in `DefaultStringInterpolation`.

### Result:

Compatibility with `logger.info("Log message", metadata: ["value": "\(value, default: "none")"])` is restored.
