### PR TITLE
Enable Xcode tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,12 +52,19 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-log-Package
-      debug_output_enabled: true
-      macos_xcode_test_enabled: false
-      ios_xcode_test_enabled: false
-      watchos_xcode_test_enabled: false
-      tvos_xcode_test_enabled: false
-      visionos_xcode_test_enabled: false
+      xcode_16_3_enabled: false
+      xcode_16_4_enabled: false
+      xcode_26_0_enabled: false
+      xcode_26_1_enabled: false
+      xcode_26_2_enabled: false
+      swift_6_1_enabled: true
+      swift_6_2_enabled: true
+      swift_6_3_enabled: true
+      macos_xcode_test_enabled: true
+      ios_xcode_test_enabled: true
+      watchos_xcode_test_enabled: true
+      tvos_xcode_test_enabled: true
+      visionos_xcode_test_enabled: true
 
   wasm:
     name: Wasm Swift SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,11 +52,6 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-log-Package
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
-      xcode_26_0_enabled: false
-      xcode_26_1_enabled: false
-      xcode_26_2_enabled: false
       swift_6_1_enabled: true
       swift_6_2_enabled: true
       swift_6_3_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,11 +58,6 @@ jobs:
       runner_pool: general
       build_scheme: swift-log-Package
       swift_test_enabled: true
-      xcode_16_3_enabled: false
-      xcode_16_4_enabled: false
-      xcode_26_0_enabled: false
-      xcode_26_1_enabled: false
-      xcode_26_2_enabled: false
       swift_6_1_enabled: true
       swift_6_2_enabled: true
       swift_6_3_enabled: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,6 +58,19 @@ jobs:
       runner_pool: general
       build_scheme: swift-log-Package
       swift_test_enabled: true
+      xcode_16_3_enabled: false
+      xcode_16_4_enabled: false
+      xcode_26_0_enabled: false
+      xcode_26_1_enabled: false
+      xcode_26_2_enabled: false
+      swift_6_1_enabled: true
+      swift_6_2_enabled: true
+      swift_6_3_enabled: true
+      macos_xcode_test_enabled: true
+      ios_xcode_test_enabled: true
+      watchos_xcode_test_enabled: true
+      tvos_xcode_test_enabled: true
+      visionos_xcode_test_enabled: true
 
   android:
     name: Android Swift SDK

--- a/Tests/LoggingTests/LogEventTest.swift
+++ b/Tests/LoggingTests/LogEventTest.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Testing
 import Foundation
+import Testing
 
 @testable import Logging
 

--- a/Tests/LoggingTests/LogEventTest.swift
+++ b/Tests/LoggingTests/LogEventTest.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Testing
+import Foundation
 
 @testable import Logging
 


### PR DESCRIPTION
Simulators seem to have stabilized in CI, we can enabled the tests.

### Motivation:

`swift-log` is expected to be used on various platforms, we should run tests against them.

### Modifications:

- Run tests on various tests in simulators in PRs and nightly.
- Fix tests to actually compile there.

### Result:

Tests are now running in simulators. Supersedes #431.