### PR TITLE
Add missing API references

### DIFF
--- a/Sources/Logging/Docs.docc/Reference/Logger-MetadataValue.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger-MetadataValue.md
@@ -9,3 +9,8 @@
 - ``array(_:)``
 - ``dictionary(_:)``
 
+### Working with attributes
+
+- ``attributed(_:attributes:)``
+- ``attributes``
+

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -13,8 +13,8 @@
 ### Task-local logger
 
 - ``current``
-- ``withLogger(_:_:)``
-- ``withLogger(mergingMetadata:_:)``
+- ``withLogger(_:_:)-(_,(Logger)(Failure)->Result)``
+- ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)``
 - ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
 
 ### Sending trace log messages

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -15,7 +15,7 @@
 - ``current``
 - ``withLogger(_:_:)``
 - ``withLogger(mergingMetadata:_:)``
-- ``withLogger(logLevel:handler:metadata:_:)``
+- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
 
 ### Sending trace log messages
 

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -10,6 +10,13 @@
 - ``init(label:factory:)-6iktu``
 - ``MetadataProvider``
 
+### Task-local logger
+
+- ``current``
+- ``withLogger(_:_:)``
+- ``withLogger(mergingMetadata:_:)``
+- ``withLogger(logLevel:handler:metadata:_:)``
+
 ### Sending trace log messages
 
 - ``trace(_:metadata:file:function:line:)``


### PR DESCRIPTION
Add missing API refs for metadata attributes and task-local logger API.

### Motivation:

API got a few new features, and they are missing from the API references.

### Modifications:

- Task-local logger API added to the references.
- Metadata attributes API added to the references.

### Result:

Docs have all the recently added APIs.
