### PR TITLE
Make `StreamLogHandler` initializers public

### DIFF
--- a/Sources/Logging/Docs.docc/Reference/StreamLogHandler.md
+++ b/Sources/Logging/Docs.docc/Reference/StreamLogHandler.md
@@ -8,6 +8,8 @@
 - ``standardOutput(label:metadataProvider:)``
 - ``standardError(label:)``
 - ``standardError(label:metadataProvider:)``
+- ``init(label:stream:)``
+- ``init(label:stream:metadataProvider:)``
 
 ### Sending log messages
 

--- a/Sources/Logging/Handlers/StreamLogHandler.swift
+++ b/Sources/Logging/Handlers/StreamLogHandler.swift
@@ -38,8 +38,6 @@ import WASILibc
 /// 2. The handler's ``metadataProvider`` is invoked, overriding any existing keys.
 /// 3. The per-log-statement metadata is merged, overriding any previously set keys.
 public struct StreamLogHandler: LogHandler {
-    internal typealias _SendableTextOutputStream = TextOutputStream & Sendable
-
     /// Creates a stream log handler that directs its output to STDOUT.
     public static func standardOutput(label: String) -> StreamLogHandler {
         StreamLogHandler(
@@ -68,7 +66,7 @@ public struct StreamLogHandler: LogHandler {
         StreamLogHandler(label: label, stream: StdioOutputStream.stderr, metadataProvider: metadataProvider)
     }
 
-    private let stream: any _SendableTextOutputStream
+    private let stream: any TextOutputStream & Sendable
     private let label: String
 
     /// Get the log level configured for this `Logger`.

--- a/Sources/Logging/Handlers/StreamLogHandler.swift
+++ b/Sources/Logging/Handlers/StreamLogHandler.swift
@@ -102,13 +102,24 @@ public struct StreamLogHandler: LogHandler {
         }
     }
 
-    // internal for testing only
-    internal init(label: String, stream: any _SendableTextOutputStream) {
+    /// Create a ``StreamLogHandler`` that directs its output to the stream you provide,
+    /// using the global metadata provider from ``LoggingSystem``.
+    ///
+    /// - parameters:
+    ///   - label: The label for this log handler.
+    ///   - stream: The stream to write log output to.
+    public init(label: String, stream: any TextOutputStream & Sendable) {
         self.init(label: label, stream: stream, metadataProvider: LoggingSystem.metadataProvider)
     }
 
-    // internal for testing only
-    internal init(label: String, stream: any _SendableTextOutputStream, metadataProvider: Logger.MetadataProvider?) {
+    /// Creates a ``StreamLogHandler`` that directs its output to the stream you provide,
+    /// using the metadata provider you provide.
+    ///
+    /// - parameters:
+    ///   - label: The label for this log handler.
+    ///   - stream: The stream to write log output to.
+    ///   - metadataProvider: The metadata provider to use, or `nil` for no provider.
+    public init(label: String, stream: any TextOutputStream & Sendable, metadataProvider: Logger.MetadataProvider?) {
         self.label = label
         self.stream = stream
         self.metadataProvider = metadataProvider

--- a/Sources/Logging/Handlers/StreamLogHandler.swift
+++ b/Sources/Logging/Handlers/StreamLogHandler.swift
@@ -112,7 +112,7 @@ public struct StreamLogHandler: LogHandler {
         self.init(label: label, stream: stream, metadataProvider: LoggingSystem.metadataProvider)
     }
 
-    /// Creates a ``StreamLogHandler`` that directs its output to the stream you provide,
+    /// Create a ``StreamLogHandler`` that directs its output to the stream you provide,
     /// using the metadata provider you provide.
     ///
     /// - parameters:

--- a/Sources/Logging/Handlers/StreamLogHandler.swift
+++ b/Sources/Logging/Handlers/StreamLogHandler.swift
@@ -102,7 +102,7 @@ public struct StreamLogHandler: LogHandler {
         }
     }
 
-    /// Create a ``StreamLogHandler`` that directs its output to the stream you provide,
+    /// Creates a ``StreamLogHandler`` that directs its output to the stream you provide,
     /// using the global metadata provider from ``LoggingSystem``.
     ///
     /// - parameters:
@@ -112,7 +112,7 @@ public struct StreamLogHandler: LogHandler {
         self.init(label: label, stream: stream, metadataProvider: LoggingSystem.metadataProvider)
     }
 
-    /// Create a ``StreamLogHandler`` that directs its output to the stream you provide,
+    /// Creates a ``StreamLogHandler`` that directs its output to the stream you provide,
     /// using the metadata provider you provide.
     ///
     /// - parameters:


### PR DESCRIPTION
Make `StreamLogHandler` initializers public.

### Motivation:

Closes https://github.com/apple/swift-log/issues/273

### Modifications:

Promote the two stream-accepting initializers from `internal` to `public`. Also as a result, their stream parameter is spelled out as `any TextOutputStream & Sendable` rather than the internal `_SendableTextOutputStream` typealias, which cannot appear in a public signature. ~The private stored property and the internal typealias are otherwise unchanged.~ The internal typealias has been completely removed as it was only used to store the stream, and the private stored property is updated to use the spelled-out type.

Also updates the docc documentation accordingly.

### Result:

Users would be able to construct a `StreamLogHandler` with their own `TextOutputStream` implementation, reusing the existing logic to format log messages and prettify metadata instead of reimplementing them.