### PR TITLE
Add missing api refs

### DIFF
--- a/Sources/Logging/Docs.docc/Proposals/Proposals.md
+++ b/Sources/Logging/Docs.docc/Proposals/Proposals.md
@@ -35,6 +35,17 @@ If you have any questions, ask in an issue on GitHub.
 
 ## Topics
 
+### Implemented Proposals
+
+- <doc:SLG-0001-metadata-providers>
+- <doc:SLG-0002>
+- <doc:SLG-0003>
+- <doc:SLG-0004-metadata-value-attributes>
+- <doc:SLG-0005-log-event-LogHandler-API>
+- <doc:SLG-0006-task-local-logger>
+
+### Proposal Template
+
 - <doc:SLG-NNNN>
 - <doc:SLG-0001-metadata-providers>
 - <doc:SLG-0002>

--- a/Sources/Logging/Docs.docc/Proposals/Proposals.md
+++ b/Sources/Logging/Docs.docc/Proposals/Proposals.md
@@ -47,9 +47,3 @@ If you have any questions, ask in an issue on GitHub.
 ### Proposal Template
 
 - <doc:SLG-NNNN>
-- <doc:SLG-0001-metadata-providers>
-- <doc:SLG-0002>
-- <doc:SLG-0003>
-- <doc:SLG-0004-metadata-value-attributes>
-- <doc:SLG-0005-log-event-LogHandler-API>
-- <doc:SLG-0006-task-local-logger>

--- a/Sources/Logging/Docs.docc/Reference/Logger-MetadataProvider.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger-MetadataProvider.md
@@ -4,7 +4,7 @@
 
 ### Creating a metadata provider
 
-- ``init(_:)-(()->Logger.Metadata)``
+- ``init(_:)``
 
 ### Invoking the provider
 

--- a/Sources/Logging/Docs.docc/Reference/Logger-MetadataValue.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger-MetadataValue.md
@@ -9,3 +9,8 @@
 - ``array(_:)``
 - ``dictionary(_:)``
 
+### Working with attributes
+
+- ``attributed(_:attributes:)``
+- ``attributes``
+

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -13,8 +13,8 @@
 ### Task-local logger
 
 - ``current``
-- ``withLogger(_:_:)``
-- ``withLogger(mergingMetadata:_:)``
+- ``withLogger(_:_:)-(_,(Logger)(Failure)->Result)``
+- ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)``
 - ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
 
 ### Sending trace log messages

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -15,7 +15,7 @@
 - ``current``
 - ``withLogger(_:_:)``
 - ``withLogger(mergingMetadata:_:)``
-- ``withLogger(logLevel:handler:metadata:_:)``
+- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
 
 ### Sending trace log messages
 

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -10,6 +10,13 @@
 - ``init(label:factory:)-6iktu``
 - ``MetadataProvider``
 
+### Task-local logger
+
+- ``current``
+- ``withLogger(_:_:)``
+- ``withLogger(mergingMetadata:_:)``
+- ``withLogger(logLevel:handler:metadata:_:)``
+
 ### Sending trace log messages
 
 - ``trace(_:metadata:file:function:line:)``

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -13,9 +13,12 @@
 ### Task-local logger
 
 - ``current``
-- ``withLogger(_:_:)-(_,(Logger)(Failure)->Result)``
-- ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)``
-- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
+- ``withLogger(_:_:)-(_,(Logger)->Result)``
+- ``withLogger(mergingMetadata:_:)-(_,(Logger)->Result)``
+- ``withLogger(_:_:)-(_,)``
+- ``withLogger(mergingMetadata:_:)-(_,)``
+- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
+- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,)``
 
 ### Sending trace log messages
 

--- a/Sources/Logging/Docs.docc/Reference/Logger.md
+++ b/Sources/Logging/Docs.docc/Reference/Logger.md
@@ -13,12 +13,12 @@
 ### Task-local logger
 
 - ``current``
-- ``withLogger(_:_:)-(_,(Logger)->Result)``
-- ``withLogger(mergingMetadata:_:)-(_,(Logger)->Result)``
-- ``withLogger(_:_:)-(_,)``
-- ``withLogger(mergingMetadata:_:)-(_,)``
-- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
-- ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,)``
+- ``withLogger(_:_:)-3dt06``
+- ``withLogger(_:_:)-70nli``
+- ``withLogger(mergingMetadata:_:)-2c7dy``
+- ``withLogger(mergingMetadata:_:)-3eduo``
+- ``withLogger(logLevel:handler:metadata:_:)-2pd9p``
+- ``withLogger(logLevel:handler:metadata:_:)-5nmw6``
 
 ### Sending trace log messages
 

--- a/Sources/Logging/Logger+With.swift
+++ b/Sources/Logging/Logger+With.swift
@@ -19,8 +19,8 @@
 /// Code called within `operation` can read the logger via ``Logger/current`` without an
 /// explicit parameter. Binding a different logger with this overload **replaces** the
 /// current task-local logger; any metadata accumulated by an outer
-/// ``withLogger(mergingMetadata:_:)-(_,)`` or
-/// ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
+/// ``withLogger(mergingMetadata:_:)-3eduo`` or
+/// ``withLogger(logLevel:handler:metadata:_:)-5nmw6``
 /// scope is not carried over. Use the modifying overloads to layer or replace aspects
 /// of the current logger instead.
 ///
@@ -29,7 +29,7 @@
 /// ``Logger/init(label:)`` consults `LoggingSystem.factory`, the constructed `Logger`
 /// only carries a useful handler once ``LoggingSystem/bootstrap(_:)`` has been called.
 /// For mid-call-tree backend swaps that should work without bootstrap (tests, scoped
-/// routing), use ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
+/// routing), use ``withLogger(logLevel:handler:metadata:_:)-5nmw6``
 /// instead — it modifies
 /// the current logger's handler in place without constructing a new one.
 ///
@@ -239,7 +239,7 @@ public func withLogger<Result, Failure: Error>(
 /// Runs `operation` with a copy of ``Logger/current`` whose aspects are **replaced** by
 /// the provided arguments. `nil` parameters leave the corresponding aspect unchanged.
 ///
-/// Unlike ``withLogger(mergingMetadata:_:)-(_,(Logger)->Result)``, which layers
+/// Unlike ``withLogger(mergingMetadata:_:)-3eduo``, which layers
 /// metadata on top of the
 /// inherited base, this overload **replaces** the base metadata when `metadata` is
 /// non-nil. Pass `metadata: [:]` to wipe the inherited metadata entirely for the scope.

--- a/Sources/Logging/Logger+With.swift
+++ b/Sources/Logging/Logger+With.swift
@@ -19,8 +19,8 @@
 /// Code called within `operation` can read the logger via ``Logger/current`` without an
 /// explicit parameter. Binding a different logger with this overload **replaces** the
 /// current task-local logger; any metadata accumulated by an outer
-/// ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)`` or
-/// ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
+/// ``withLogger(mergingMetadata:_:)-(_,)`` or
+/// ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
 /// scope is not carried over. Use the modifying overloads to layer or replace aspects
 /// of the current logger instead.
 ///
@@ -29,7 +29,7 @@
 /// ``Logger/init(label:)`` consults `LoggingSystem.factory`, the constructed `Logger`
 /// only carries a useful handler once ``LoggingSystem/bootstrap(_:)`` has been called.
 /// For mid-call-tree backend swaps that should work without bootstrap (tests, scoped
-/// routing), use ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)(Failure)->Result)``
+/// routing), use ``withLogger(logLevel:handler:metadata:_:)-(_,_,_,(Logger)->Result)``
 /// instead — it modifies
 /// the current logger's handler in place without constructing a new one.
 ///
@@ -132,7 +132,7 @@ public func withLogger<Result, Failure: Error>(
 /// `metadata`) are preserved.
 ///
 /// Use this overload at request boundaries and any point where context should
-/// accumulate. Nested ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)`` scopes
+/// accumulate. Nested ``withLogger(mergingMetadata:_:)`` scopes
 /// layer on top of each
 /// other.
 ///
@@ -239,7 +239,7 @@ public func withLogger<Result, Failure: Error>(
 /// Runs `operation` with a copy of ``Logger/current`` whose aspects are **replaced** by
 /// the provided arguments. `nil` parameters leave the corresponding aspect unchanged.
 ///
-/// Unlike ``withLogger(mergingMetadata:_:)-(_,(Logger)(Failure)->Result)``, which layers
+/// Unlike ``withLogger(mergingMetadata:_:)-(_,(Logger)->Result)``, which layers
 /// metadata on top of the
 /// inherited base, this overload **replaces** the base metadata when `metadata` is
 /// non-nil. Pass `metadata: [:]` to wipe the inherited metadata entirely for the scope.

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -1514,7 +1514,7 @@ extension Logger {
     /// The current task-local logger.
     ///
     /// Returns the logger bound by the nearest enclosing
-    /// ``withLogger(_:_:)-(_,(Logger)(Failure)->Result)`` scope. If none is active, returns the
+    /// ``withLogger(_:_:)-(_,(Logger)->Result)`` scope. If none is active, returns the
     /// process-wide unbound default — a `Logger(label: "")` constructed via
     /// `LoggingSystem.factory` the first time the task-local is touched, then reused for
     /// the lifetime of the process. The empty label is the deliberate diagnostic signal

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -1514,7 +1514,7 @@ extension Logger {
     /// The current task-local logger.
     ///
     /// Returns the logger bound by the nearest enclosing
-    /// ``withLogger(_:_:)-(_,(Logger)->Result)`` scope. If none is active, returns the
+    /// ``withLogger(_:_:)-70nli`` scope. If none is active, returns the
     /// process-wide unbound default — a `Logger(label: "")` constructed via
     /// `LoggingSystem.factory` the first time the task-local is touched, then reused for
     /// the lifetime of the process. The empty label is the deliberate diagnostic signal


### PR DESCRIPTION
Expands on @kukushechkin #474 (add-missing API) and tacks in some additional work

### Motivation:

resolve the DocC warnings

### Modifications:

- resolves docc warnings for soundness checks 
- updates curation to drop the task-local logger updates into the correct areas
- updates curation to collect the implemented proposals together

### Result:

Hopefully no issues with soundness checks
