### PR TITLE
Handle Windows path separators in Logger.currentModule(filePath:)

### DIFF
--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -1374,9 +1374,12 @@ extension Logger {
 extension Logger {
     @inlinable
     internal static func currentModule(filePath: String = #file) -> String {
+        // `#file` paths use the platform's path separator, so on Windows the
+        // components are separated by backslashes rather than slashes.
+        let isPathSeparator: (UInt8) -> Bool = { $0 == UInt8(ascii: "/") || $0 == UInt8(ascii: "\\") }
         let utf8All = filePath.utf8
-        return filePath.utf8.lastIndex(of: UInt8(ascii: "/")).flatMap { lastSlash -> Substring? in
-            utf8All[..<lastSlash].lastIndex(of: UInt8(ascii: "/")).map { secondLastSlash -> Substring in
+        return utf8All.lastIndex(where: isPathSeparator).flatMap { lastSlash -> Substring? in
+            utf8All[..<lastSlash].lastIndex(where: isPathSeparator).map { secondLastSlash -> Substring in
                 filePath[utf8All.index(after: secondLastSlash)..<lastSlash]
             }
         }.map {

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -1143,6 +1143,21 @@ struct LoggingTest {
         #expect(.error == logger1.logLevel)
         #expect(.trace == logger2.logLevel)
     }
+
+    @Test func currentModuleFromFilePath() {
+        // POSIX-style paths, as produced by `#file` on Darwin and Linux
+        #expect(Logger.currentModule(filePath: "/home/user/project/Sources/MyModule/File.swift") == "MyModule")
+        #expect(Logger.currentModule(filePath: "Sources/MyModule/File.swift") == "MyModule")
+
+        // Windows-style paths, as produced by `#file` on Windows
+        #expect(Logger.currentModule(filePath: #"C:\Users\user\project\Sources\MyModule\File.swift"#) == "MyModule")
+        #expect(Logger.currentModule(filePath: #"Sources\MyModule\File.swift"#) == "MyModule")
+
+        // Not enough path components to determine a module
+        #expect(Logger.currentModule(filePath: "File.swift") == "n/a")
+        #expect(Logger.currentModule(filePath: "MyModule/File.swift") == "n/a")
+        #expect(Logger.currentModule(filePath: #"MyModule\File.swift"#) == "n/a")
+    }
 }
 
 extension Logger {


### PR DESCRIPTION
### Motivation

`Logger.currentModule(filePath:)` derives a log's `source` from `#file` by taking the second-to-last path component — but it only recognizes `/` as a path separator. On Windows, `#file` produces backslash-separated paths (`C:\...\Sources\MyModule\File.swift`), so the lookup finds no separator and falls through to `"n/a"`. Every log emitted through the deprecated file-based `LogHandler` compatibility path (`LogHandler.swift`'s `log(level:...file:...)` shim, which calls `currentModule(filePath: file)`) therefore reports `source: n/a` on Windows instead of the module name, breaking source-based filtering.

The `#fileID`-based overload is unaffected (`#fileID` always uses `/`).

### Modifications

- `currentModule(filePath:)` now treats both `/` and `\` as path separators when extracting the second-to-last component.
- Added `currentModuleFromFilePath` tests covering POSIX-style paths, Windows-style paths, and paths with too few components. The Windows cases fail against the previous implementation and pass with this change.

### Result

Logs emitted on Windows via the deprecated file-based API report the correct module as their `source`. No behavior change on Darwin/Linux (all 165 existing tests pass unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)