### PR TITLE
Correct MultiplexLogHandler metadata priority documentation

### DIFF
--- a/Sources/Logging/Handlers/MultiplexLogHandler.swift
+++ b/Sources/Logging/Handlers/MultiplexLogHandler.swift
@@ -45,20 +45,28 @@
 /// observe this change.
 ///
 /// Reading metadata from the multiplex log handler MAY need to pick one of conflicting values if the underlying log handlers
-/// were previously initiated with metadata before passing them into the multiplex handler. The multiplex handler uses
-/// the order in which the handlers were passed in during its initialization as a priority indicator - the first handler's
-/// values are more important than the next handlers values, etc.
+/// were previously initiated with metadata before passing them into the multiplex handler. Which value wins depends on how
+/// the metadata is queried.
+///
+/// When a single key is queried with `subscript(metadataKey:)`, the multiplex handler uses the order in which the handlers
+/// were passed in during its initialization as a priority indicator - the first handler that has a value for the queried
+/// key provides the value.
 ///
 /// Example:
 /// If the multiplex log handler was initiated with two handlers like this: `MultiplexLogHandler([handler1, handler2])`.
 /// The handlers each have some already set metadata: `handler1` has metadata values for keys `one` and `all`, and `handler2`
 /// has values for keys `two` and `all`.
 ///
-/// A query through the multiplex log handler the key `one` naturally returns `handler1`'s value, and a query for `two`
+/// A query through the multiplex log handler for the key `one` naturally returns `handler1`'s value, and a query for `two`
 /// naturally returns `handler2`'s value.
-/// Querying for the key `all` will return `handler1`'s value, as that handler has a high priority,
+/// Querying for the key `all` will return `handler1`'s value, as that handler has a higher priority,
 /// as indicated by its earlier position in the initialization, than the second handler.
-/// The same rule applies when querying for the `metadata` property of the multiplex log handler; it constructs `Metadata` uniquing values.
+///
+/// The opposite priority applies when reading the `metadata` property: the combined `Metadata` is built by merging the
+/// handlers' metadata in initialization order, with values from later handlers overriding values from earlier ones - in
+/// the example above, the `metadata` dictionary contains `handler2`'s value for the key `all`. Values obtained from the
+/// handlers' metadata providers override stored handler metadata, and the multiplex handler's own metadata provider, if
+/// set, is applied last.
 public struct MultiplexLogHandler: LogHandler {
     private var handlers: [any LogHandler]
     private var effectiveLogLevel: Logger.Level

--- a/Tests/LoggingTests/LoggingTest.swift
+++ b/Tests/LoggingTests/LoggingTest.swift
@@ -281,6 +281,12 @@ struct LoggingTest {
                 "in": "in-2",
             ]
         )
+
+        // unlike the metadata property, the single-key subscript prefers the FIRST handler
+        // that has a value for the queried key
+        #expect(multiplexLogger.handler[metadataKey: "one"] == "111")
+        #expect(multiplexLogger.handler[metadataKey: "two"] == "222")
+        #expect(multiplexLogger.handler[metadataKey: "in"] == "in-1")
     }
 
     @Test func multiplexMetadataProviderSet() {


### PR DESCRIPTION
### Motivation

The `MultiplexLogHandler` doc comment states that the first handler's values take priority when reading metadata, and that "The same rule applies when querying for the `metadata` property of the multiplex log handler". The implementation does the opposite for the `metadata` property — and that behavior is deliberately pinned by the existing `multiplexLogHandlerMetadata_readingHandlerMetadata` test, which expects `"in": "in-2"` (the *second* handler's value) for a conflicting key:

```swift
effective.merge(handler.metadata, uniquingKeysWith: { _, handlerMetadata in handlerMetadata })
```

So today:
- `subscript(metadataKey:)` → first handler with the key wins (matches the docs)
- `metadata` property → later handlers override earlier ones; provider values override stored metadata; the multiplex handler's own provider is applied last (contradicts the docs)

Since the current merge behavior is tested and changing it would be a breaking behavior change, the documentation is what should be fixed.

### Modifications

- Rewrote the "Effective Logger.Metadata" section of the doc comment to describe both accessors accurately, including the provider layering (handler metadata → handler providers → multiplex's own provider).
- Added assertions to `multiplexLogHandlerMetadata_readingHandlerMetadata` pinning the subscript's first-handler-wins behavior for conflicting keys, so both documented behaviors are now covered by tests.

### Result

The public API documentation matches the implemented and tested behavior. No code behavior changes; all 164 tests pass.

If the maintainers would rather unify the two accessors' priority instead (a semver-major behavior change), happy to rework this in that direction — but the docs shouldn't promise something the tests forbid in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)