### PR TITLE
Make `ReadWriteLock.init` `internal`

### DIFF
--- a/Sources/Logging/Locks.swift
+++ b/Sources/Logging/Locks.swift
@@ -196,7 +196,7 @@ internal final class ReadWriteLock: @unchecked Sendable {
     #endif
 
     /// Create a new lock.
-    public init() {
+    init() {
         #if os(Windows)
         InitializeSRWLock(self.rwlock)
         #elseif (compiler(<6.1) && !os(WASI)) || (compiler(>=6.1) && _runtime(_multithreaded))


### PR DESCRIPTION
### Motivation:

`public` init has no effect for an `internal` class.

### Modifications:

Removed `public` from the `ReadWriteLock.init`.

### Result:

`ReadWriteLock.init` is now `internal`, matching class visibility.